### PR TITLE
Fixed print statement for python3 compatibility

### DIFF
--- a/sublime_jedi.py
+++ b/sublime_jedi.py
@@ -25,7 +25,7 @@ def get_sys_path(python_interpreter):
 
         :return: list
     """
-    command = [python_interpreter, '-c', "import sys; print sys.path"]
+    command = [python_interpreter, '-c', "import sys; print(sys.path)"]
     process = subprocess.Popen(command, shell=False, stdout=subprocess.PIPE)
     out = process.communicate()[0]
     sys_path = json.loads(out.replace("'", '"'))


### PR DESCRIPTION
In my use case I had a virtual environment configured with python3 and some libraries and in Sublime I configured the project to work with the libraries and the executable from the virtual environment like this:

```
"settings":
{
    "python_interpreter_path": "/path/to/project/venv/bin/python",
    "python_package_paths": [
                "/path/to/project/venv/lib/python3.3/",
                "/path/to/project/venv/lib/python3.3/site-packages"
            ]
}
```

When doing this the autocomplete function gives an error about the specific print statement I fixed here. When using parenthesis everything works fine!
