### PR TITLE
Fixed imports on ST3.

### DIFF
--- a/jedi_daemon.py
+++ b/jedi_daemon.py
@@ -6,6 +6,12 @@ import logging
 from logging import handlers
 from optparse import OptionParser
 
+try:
+    from SublimeJEDI import sublime_jedi  # fix imports on ST3
+    del sublime_jedi
+except ImportError:
+    pass
+
 import jedi
 from jedi.api import NotFoundError
 


### PR DESCRIPTION
I tried the latest daemon changes on ST3, but I got: `ImportError: No module named 'jedi'`. The reason is that `jedi_daemon` is imported before `sublime_jedi` (which patches sys.path to make imports work). 
