### PR TITLE
don't autocomplete in SublimeREPL views

### DIFF
--- a/sublime_jedi.py
+++ b/sublime_jedi.py
@@ -170,6 +170,10 @@ class Autocomplete(sublime_plugin.EventListener):
                 return [tuple(i) for i in cplns]
             return
 
+        if view.settings().get("repl", False):
+            logger.debug("JEDI does not complete in SublimeREPL views")
+            return
+
         # nothing to do with non-python code
         if not is_python_scope(view, locations[0]):
             logger.debug('JEDI does not complete in strings')


### PR DESCRIPTION
argument expansion still works, but autocomplete was conflicting
with IPython's one, I might add detection in the future to reenable
SublimeJEDI autocomplete for plain python repls (w/o ipython) but
this would also require SublimeJEDI python_interpreter_path ovveride
on per view basis to provide meaningful results
