### PR TITLE
Restrict keymaps to Python and make modifiers consistent

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -4,7 +4,7 @@
             {"key": "selector", "operator": "equal", "operand":  "source.python"}
         ]
     },
-    {"command": "sublime_jedi_find_usages", "keys": ["alt+shift+f"],
+    {"command": "sublime_jedi_find_usages", "keys": ["ctrl+shift+f"],
         "context": [
             {"key": "selector", "operator": "equal", "operand":  "source.python"}
         ]


### PR DESCRIPTION
If you decide to make the keymap modifiers consistent then `README.md` will need to be updated accordingly.
