### PR TITLE
Tiny syntax correction to JEDI settings example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can set Python interpreter, and additional python package directories, using
 
         "settings": {
             // ...
-            "python_interpreter_path": "/home/sr/.virtualenvs/django1.5/bin/python"
+            "python_interpreter_path": "/home/sr/.virtualenvs/django1.5/bin/python",
 
             "python_package_paths": [
                 "/home/sr/python_packages1",


### PR DESCRIPTION
I'm sure a lot of people copy-paste those settings and that missing comma will cause it to fail.
