### PR TITLE
Fix messages.json

### DIFF
--- a/messages.json
+++ b/messages.json
@@ -1,8 +1,8 @@
 {
-	"0.6.1": "messages/0.6.1.txt",
+    "0.6.1": "messages/0.6.1.txt",
     "0.6.2": "messages/0.6.2.txt",
     "0.6.3": "messages/0.6.3.txt",
     "0.6.4": "messages/0.6.4.txt",
-    "0.6.5": "messages/0.6.5.txt"
+    "0.6.5": "messages/0.6.5.txt",
     "0.6.6": "messages/0.6.6.txt"
 }


### PR DESCRIPTION
Fix "Package Control: Error parsing messages.json for Jedi - Python autocompletion" on package install.
Replace tab for 4 spaces for consistency.
