### PR TITLE
Fix 'data' being referenced before assignment

### DIFF
--- a/sublime_jedi/utils.py
+++ b/sublime_jedi/utils.py
@@ -50,6 +50,7 @@ class ThreadReader(BaseThread):
         while not self.done:
             line = self.fd.readline()
             if line:
+                data = None
                 try:
                     data = json.loads(line.strip())
                 except ValueError:


### PR DESCRIPTION
It seems that at first scan of a new symbol/module, there are a number of json errors generated. But before that even happened I was getting no completion at all because of a reference to 'data' in the exception handling when it wasn't defined. After fixing that, though I still see a number of json decode errors, eventually it does complete and stop erroring.

Example of errors:

``` python
# When completing on QtCore.
sublime_jedi.utils: Non JSON data from daemon: Traceback (most recent call last):

Traceback (most recent call last):
  File "./sublime_jedi/utils.py", line 55, in run
  File ".\json\__init__.py", line 307, in loads
  File ".\json\decoder.py", line 319, in decode
  File ".\json\decoder.py", line 338, in raw_decode
ValueError: No JSON object could be decoded
sublime_jedi.utils: Non JSON data from daemon:   File "/vol/apps/python-2.6.4_64/lib/python2.6/logging/__init__.py", line 768, in emit

Traceback (most recent call last):
  File "./sublime_jedi/utils.py", line 55, in run
  File ".\json\__init__.py", line 307, in loads
  File ".\json\decoder.py", line 319, in decode
  File ".\json\decoder.py", line 338, in raw_decode
ValueError: No JSON object could be decoded
sublime_jedi.utils: Non JSON data from daemon:     msg = self.format(record)

Traceback (most recent call last):
  File "./sublime_jedi/utils.py", line 55, in run
  File ".\json\__init__.py", line 307, in loads
  File ".\json\decoder.py", line 319, in decode
  File ".\json\decoder.py", line 338, in raw_decode
ValueError: No JSON object could be decoded
sublime_jedi.utils: Non JSON data from daemon:   File "/vol/apps/python-2.6.4_64/lib/python2.6/logging/__init__.py", line 648, in format

Traceback (most recent call last):
  File "./sublime_jedi/utils.py", line 55, in run
  File ".\json\__init__.py", line 307, in loads
  File ".\json\decoder.py", line 319, in decode
  File ".\json\decoder.py", line 338, in raw_decode
ValueError: No JSON object could be decoded
sublime_jedi.utils: Non JSON data from daemon:     return fmt.format(record)

Traceback (most recent call last):
  File "./sublime_jedi/utils.py", line 55, in run
  File ".\json\__init__.py", line 307, in loads
  File ".\json\decoder.py", line 319, in decode
  File ".\json\decoder.py", line 338, in raw_decode
ValueError: No JSON object could be decoded
sublime_jedi.utils: Non JSON data from daemon:   File "daemon.py", line 23, in format

Traceback (most recent call last):
  File "./sublime_jedi/utils.py", line 55, in run
  File ".\json\__init__.py", line 307, in loads
  File ".\json\decoder.py", line 319, in decode
  File ".\json\decoder.py", line 338, in raw_decode
ValueError: No JSON object could be decoded
sublime_jedi.utils: Non JSON data from daemon:     output = super(JsonFormatter, self).format(record)

Traceback (most recent call last):
  File "./sublime_jedi/utils.py", line 55, in run
  File ".\json\__init__.py", line 307, in loads
  File ".\json\decoder.py", line 319, in decode
  File ".\json\decoder.py", line 338, in raw_decode
ValueError: No JSON object could be decoded
sublime_jedi.utils: Non JSON data from daemon: TypeError: super() argument 1 must be type, not classobj

Traceback (most recent call last):
  File "./sublime_jedi/utils.py", line 55, in run
  File ".\json\__init__.py", line 307, in loads
  File ".\json\decoder.py", line 319, in decode
  File ".\json\decoder.py", line 338, in raw_decode
ValueError: No JSON object could be decoded

```
