### PR TITLE
let python_interpreter_path can use '$project_path'

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can set Python interpreter, and additional python package directories, using
         }
     }
 
-Note that the `python_interpreter_path` should be absolute path.
+Note that the `python_interpreter_path` and `python_package_paths` should be absolute path.
 If necessary you can use `$project_path` to present project's folder path.
 
 #### Autocomplete on DOT

--- a/sublime_jedi/utils.py
+++ b/sublime_jedi/utils.py
@@ -230,11 +230,11 @@ def get_settings(view):
                       'Please, use `python_interpreter` instead.',
                       DeprecationWarning)
 
-    if python_interpreter.startswith('$project_path'):
-        project_dir = os.path.dirname(view.window().project_file_name())
-        python_interpreter = python_interpreter.replace('$project_path', project_dir, 1)
+    python_interpreter = expand_project_path(view, python_interpreter)
 
     extra_packages = get_settings_param(view, 'python_package_paths', [])
+    extra_packages = [expand_project_path(view, p) for p in extra_packages]
+
     complete_funcargs = get_settings_param(view,
                                            'auto_complete_function_params',
                                            'all')
@@ -276,3 +276,18 @@ def to_relative_path(path):
             return path.replace(folder, '')
 
     return path
+
+
+def expand_project_path(view, path):
+    """
+    expand variable `$project_path` in **path** to project's path
+
+    :type view: sublime.View
+    :type path: str
+    :rtype: str
+    """
+    if path.startswith('$project_path'):
+        project_dir = os.path.dirname(view.window().project_file_name())
+        return path.replace('$project_path', project_dir, 1)
+    else:
+        return path


### PR DESCRIPTION
Currently the 'python_interpreter_path' in project setting has to be absolute path, and may not proper to be submitted into source control. I think it's better to allow using '$project_path' to present the project's path, just like other sublime settings.
