### PR TITLE
workaround ST2 segfault on empty completion entry

### DIFF
--- a/sublime_jedi/completion.py
+++ b/sublime_jedi/completion.py
@@ -176,7 +176,12 @@ class Autocomplete(sublime_plugin.EventListener):
         # XXX check position
         self.cplns_ready = True
         if completions:
-            self.completions = completions
+            # completions is a list of (text to show in the dropdown, 
+            #   contents to enter) - eg. [(u'class\tkeyword', u'class')]
+            # If however the first entry in the tumple is the empty string,
+            # ST2 build 2221 segfaults. Filter out the faulty tuples.
+            self.completions = [compl for compl in completions if compl[0]]
+
             view.run_command("hide_auto_complete")
             sublime.set_timeout(functools.partial(self.show, view), 0)
 


### PR DESCRIPTION
It seems Sublime Text 2 (build 2221) doesn't really like it when the completion list contains empty strings and segfaults. This originally happened to me when trying to complete arguments for timedelta.
Steps to reproduce:
- use Sublime Text 2 (build 2221, ie. the newest release) with the newest SublimeJEDI plugin
- edit a python module
- import timedelta:  `from datetime import timedelta`
- enter `timedelta(ho` (as in hour, but minute and the rest might also work) and wait for the completion dropdown to appear
- ST2 crashes with a segmentation fault

Here's a minimal plugin that crashes ST2 for me:

``` python
import sublime_plugin

class ExampleEventListener(sublime_plugin.EventListener):
    def on_query_completions(self, view, prefix, locations):
        return [(u'', u'foo')]
```

I tried it on two systems, both were 64-bit ubuntu.
