### PR TITLE
expand variables in path

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Also you can set different interpreter for each Sublime Project.
 To set project related Python interpreter you have to edit yours project config file.
 By default project config name is `<project name>.sublime-project`
 
-You can set Python interpreter, and additional python package directories, using following:
+You can set Python interpreter, and additional python package directories, using for example following:
 
     # <project name>.sublime-project
     {
@@ -41,18 +41,18 @@ You can set Python interpreter, and additional python package directories, using
 
         "settings": {
             // ...
-            "python_interpreter_path": "/home/sr/.virtualenvs/django1.5/bin/python",
+            "python_interpreter": "$project_path/../../virtual/bin/python",
 
             "python_package_paths": [
-                "/home/sr/python_packages1",
-                "/home/sr/python_packages2",
-                "/home/sr/python_packages3"
+                "$home/.buildout/eggs",
+                "$project_path/addons",
                 ]
         }
     }
 
-Note that the `python_interpreter_path` and `python_package_paths` should be absolute path.
-If necessary you can use `$project_path` to present project's folder path.
+When setting paths, [Sublime Text Build System Variables](http://docs.sublimetext.info/en/latest/reference/build_systems.html#build-system-variables) and OS environment variables are automatically expanded.
+Note that using placeholders and substitutions, like in regular Sublime Text Build System paths is not supported.
+
 
 #### Autocomplete on DOT
 
@@ -83,13 +83,13 @@ Function parameters completion has 3 different behavior:
   - insert all function arguments on autocomplete (default behavior)
 
         # complete result
-        func(a, b, c, d=True, e=1, f=None)        
+        func(a, b, c, d=True, e=1, f=None)
 
         # sublime_jedi.sublime-settins
         {
             "auto_complete_function_params": "all"
-        }	
-    
+        }
+
 
   - insert arguments that don't have default value (e.g. required)
 
@@ -102,7 +102,7 @@ Function parameters completion has 3 different behavior:
         }
 
   - do not insert any arguments
-        
+
         # complete result
         func()
 
@@ -115,14 +115,14 @@ Function parameters completion has 3 different behavior:
 
 Find function / variable / class definition
 
-Shortcuts: `CTRL+SHIFT+G` 
+Shortcuts: `CTRL+SHIFT+G`
 
 Mouse binding, was disabled, becase it's hard to keep ST default behavior.
 Now you can bind `CTRL + LeftMouseButton` by themself in this way:
 
     # User/Default.sublime-mousemap
     [{
-        "modifiers": ["ctrl"], "button": "button1", 
+        "modifiers": ["ctrl"], "button": "button1",
         "command": "sublime_jedi_goto",
         "press_command": "drag_select"
     }]

--- a/sublime_jedi/utils.py
+++ b/sublime_jedi/utils.py
@@ -321,11 +321,7 @@ def expand_path(view, path):
             exp_path = os.path.normpath(os.path.expandvars(exp_path))
             if os.path.exists(exp_path):
                 path = exp_path
-    except Exception as e:
-        try:
-            msg = e.message
-        except AttributeError:
-            msg = repr(e)
-        logger.exception('Exception while expanding "{}": {}'.format(path, msg))
+    except Exception:
+        logger.exception('Exception while expanding "{}"'.format(path))
 
     return path

--- a/sublime_jedi/utils.py
+++ b/sublime_jedi/utils.py
@@ -230,10 +230,10 @@ def get_settings(view):
                       'Please, use `python_interpreter` instead.',
                       DeprecationWarning)
 
-    python_interpreter = expand_project_path(view, python_interpreter)
+    python_interpreter = expand_path(view, python_interpreter)
 
     extra_packages = get_settings_param(view, 'python_package_paths', [])
-    extra_packages = [expand_project_path(view, p) for p in extra_packages]
+    extra_packages = [expand_path(view, p) for p in extra_packages]
 
     complete_funcargs = get_settings_param(view,
                                            'auto_complete_function_params',
@@ -260,6 +260,13 @@ def is_python_scope(view, location):
     return view.match_selector(location, "source.python - string - comment")
 
 
+def is_repl(view):
+    """
+    Is SublimeREPL ?
+    """
+    return view.settings().get("repl", False)
+
+
 def to_relative_path(path):
     """
     Trim project root pathes from **path** passed as argument
@@ -278,16 +285,47 @@ def to_relative_path(path):
     return path
 
 
-def expand_project_path(view, path):
+def split_path(d, keys):
+    assert isinstance(d, dict) and isinstance(keys, list)
+    for k in [x for x in keys if d.get(x) and d[x] and os.path.exists(d[x])]:
+        d['%s_path' % (k,)], d['%s_name' % (k,)] = os.path.split(d[k])
+        d['%s_base_name' % (k,)], d['%s_extension' % (k,)] = \
+            os.path.splitext(d['%s_name' % (k,)])
+        d['%s_extension' % (k,)] = d['%s_extension' % (k,)].lstrip('.')
+    return d
+
+
+def expand_path(view, path):
     """
-    expand variable `$project_path` in **path** to project's path
+    Expand ST build system and OS environment variables to normalized path
+    that allows collapsing up-level references for basic path manipulation
+    through combination of variables and/or separators, i.e.:
+        "python_interpreter": "$project_path/../../virtual/bin/python",
+        "python_package_paths": ["$home/.buildout/eggs"]
 
     :type view: sublime.View
     :type path: str
     :rtype: str
     """
-    if path.startswith('$project_path'):
-        project_dir = os.path.dirname(view.window().project_file_name())
-        return path.replace('$project_path', project_dir, 1)
-    else:
-        return path
+    subl_vars = {}
+    try:
+        subl_vars['$file'] = view.file_name()
+        subl_vars['$packages'] = sublime.packages_path()
+        subl_vars['$project'] = view.window().project_file_name()
+        subl_vars = split_path(subl_vars, ['$file', '$project'])
+        if '$' in path or '%' in path:
+            exp_path = path
+            for k in sorted(subl_vars, key=len, reverse=True):
+                if subl_vars[k]:
+                    exp_path = exp_path.replace(k, subl_vars[k])
+            exp_path = os.path.normpath(os.path.expandvars(exp_path))
+            if os.path.exists(exp_path):
+                path = exp_path
+    except Exception as e:
+        try:
+            msg = e.message
+        except AttributeError:
+            msg = repr(e)
+        logger.debug('Exception while expanding "{}": {}'.format(path, msg))
+
+    return path

--- a/sublime_jedi/utils.py
+++ b/sublime_jedi/utils.py
@@ -287,11 +287,11 @@ def to_relative_path(path):
 
 def split_path(d, keys):
     assert isinstance(d, dict) and isinstance(keys, list)
-    for k in [x for x in keys if d.get(x) and d[x] and os.path.exists(d[x])]:
-        d['%s_path' % (k,)], d['%s_name' % (k,)] = os.path.split(d[k])
-        d['%s_base_name' % (k,)], d['%s_extension' % (k,)] = \
-            os.path.splitext(d['%s_name' % (k,)])
-        d['%s_extension' % (k,)] = d['%s_extension' % (k,)].lstrip('.')
+    for k in [x for x in keys if d.get(x) and os.path.exists(d[x])]:
+        d['%s_path' % k], d['%s_name' % k] = os.path.split(d[k])
+        d['%s_base_name' % k], d['%s_extension' % k] = \
+            os.path.splitext(d['%s_name' % k])
+        d['%s_extension' % k] = d['%s_extension' % k].lstrip('.')
     return d
 
 
@@ -326,6 +326,6 @@ def expand_path(view, path):
             msg = e.message
         except AttributeError:
             msg = repr(e)
-        logger.debug('Exception while expanding "{}": {}'.format(path, msg))
+        logger.exception('Exception while expanding "{}": {}'.format(path, msg))
 
     return path


### PR DESCRIPTION
Closes https://github.com/srusskih/SublimeJEDI/issues/159

Modified function operates on dict `subl_vars` with keys as in [build-system-variables](http://docs.sublimetext.info/en/latest/reference/build_systems.html#build-system-variables) and according values.

It also expands OS env vars, which all are tested to work correctly on Linux and Windows.

Maybe this problem can be approached also differently like in SublimeRepl build hack - calling daemon though custom build command (if possible, I haven't looked at it) that would accept ST build variables that would further allow using placeholders and substitutions.