### PR TITLE
add option to show goto definitions in a split view

### DIFF
--- a/sublime_jedi.sublime-settings
+++ b/sublime_jedi.sublime-settings
@@ -20,5 +20,13 @@
     // "all" - both jedi's and sublime's
     // "jedi" - only jedi's
     // "default" - only jedi's if it has something to show, otherwise sublime's
-    "sublime_completions_visibility": "default"
+    "sublime_completions_visibility": "default",
+
+    // how to open goto definition result with ability to show it transient
+    // variation (preview only. it won't have a tab assigned it until modified):
+    // "single-panel" - opens a file in same layout (default)
+    // "single-transient" - opens a file in same layout but transient
+    // "two-panel" - opens a file in a split layout
+    // "two-panel-transient" - opens a file in a split layout but transient
+    "sublime_goto_layout": "single-panel"
 }

--- a/sublime_jedi.sublime-settings
+++ b/sublime_jedi.sublime-settings
@@ -25,8 +25,8 @@
     // how to open goto definition result with ability to show it transient
     // variation (preview only. it won't have a tab assigned it until modified):
     // "single-panel" - opens a file in same layout (default)
-    // "single-transient" - opens a file in same layout but transient
-    // "two-panel" - opens a file in a split layout
-    // "two-panel-transient" - opens a file in a split layout but transient
+    // "single-panel-transient" - same as above but in transient mode
+    // "two-panel" - opens a file in a split to two columns layout
+    // "two-panel-transient" - same as above but in transient mode
     "sublime_goto_layout": "single-panel"
 }

--- a/sublime_jedi/go_to.py
+++ b/sublime_jedi/go_to.py
@@ -92,7 +92,8 @@ class BaseLookUpJediCommand(object):
             window.views_in_group(curr_group)
         ])
         if filename and filename in files_in_curr_group:
-            window.set_view_index(files_in_curr_group[filename], selected_group, 0)
+            if files_in_curr_group[filename].view_id != self.view.view_id:
+                window.set_view_index(files_in_curr_group[filename], selected_group, 0)
 
     def _window_quick_panel_open_window(self, view, options):
         """ Shows the active `sublime.Window` quickpanel (dropdown) for

--- a/sublime_jedi/go_to.py
+++ b/sublime_jedi/go_to.py
@@ -51,14 +51,14 @@ class BaseLookUpJediCommand(object):
 
     def prepare_layout(self, window, transient, filename):
         """
-        prepares the layout of the window to configured and returns a flags
+        prepares the layout of the window to configured and returns flags
         for opening the file
         """
         flags = sublime.ENCODED_POSITION
         if transient:
             flags |= sublime.TRANSIENT
         goto_layout = get_settings_param(self.view, 'sublime_goto_layout')
-        if goto_layout == 'single-transient' and not transient:
+        if goto_layout == 'single-panel-transient' and not transient:
             flags |= sublime.TRANSIENT
         elif goto_layout == 'two-panel':
             self.switch_to_two_panel_layout(window, filename)
@@ -78,7 +78,7 @@ class BaseLookUpJediCommand(object):
                 'rows': [0.0, 1.0],
                 'cells': [[0, 0, 1, 1], [1, 0, 2, 1]],
             })
-            # select non current group(panel)
+        # select non current group(panel)
         selected_group = None
         for group in range(window.num_groups()):
             if group != curr_group:
@@ -86,7 +86,7 @@ class BaseLookUpJediCommand(object):
                 window.focus_group(group)
                 break
         # if the file is already opened and is in current group
-        # move it to another panel. or we shouldn't ?
+        # move it to another panel.
         files_in_curr_group = dict([
             (i.file_name(), i) for i in
             window.views_in_group(curr_group)

--- a/sublime_jedi/go_to.py
+++ b/sublime_jedi/go_to.py
@@ -4,6 +4,7 @@ import sublime_plugin
 from functools import partial
 
 from .utils import to_relative_path, ask_daemon, is_python_scope
+from .settings import get_settings_param
 
 
 class BaseLookUpJediCommand(object):
@@ -24,7 +25,7 @@ class BaseLookUpJediCommand(object):
 
             If transient is True, opens a transient view
         """
-        active_window = sublime.active_window()
+        active_window = self.view.window()
 
         # restore saved location
         try:
@@ -43,11 +44,55 @@ class BaseLookUpJediCommand(object):
                 self.view.show(self.point)
                 return
             filename, line_number, column_number = self.options[filename]
+
+        flags = self.prepare_layout(active_window, transient, filename)
+        active_window.open_file('%s:%s:%s' % (filename, line_number or 0,
+                                column_number or 0), flags)
+
+    def prepare_layout(self, window, transient, filename):
+        """
+        prepares the layout of the window to configured and returns a flags
+        for opening the file
+        """
         flags = sublime.ENCODED_POSITION
         if transient:
             flags |= sublime.TRANSIENT
-        active_window.open_file('%s:%s:%s' % (filename, line_number or 0,
-                                column_number or 0), flags)
+        goto_layout = get_settings_param(self.view, 'sublime_goto_layout')
+        if goto_layout == 'single-transient' and not transient:
+            flags |= sublime.TRANSIENT
+        elif goto_layout == 'two-panel':
+            self.switch_to_two_panel_layout(window, filename)
+        elif goto_layout == 'two-panel-transient':
+            self.switch_to_two_panel_layout(window, filename)
+            if not transient:
+                flags |= sublime.TRANSIENT
+        return flags
+
+    def switch_to_two_panel_layout(self, window, filename):
+        curr_group = window.active_group()
+        layout = window.get_layout()
+        if len(layout['cells']) == 1:
+            # currently a single panel layout so switch to two panels
+            window.set_layout({
+                'cols': [0.0, 0.5, 1.0],
+                'rows': [0.0, 1.0],
+                'cells': [[0, 0, 1, 1], [1, 0, 2, 1]],
+            })
+            # select non current group(panel)
+        selected_group = None
+        for group in range(window.num_groups()):
+            if group != curr_group:
+                selected_group = group
+                window.focus_group(group)
+                break
+        # if the file is already opened and is in current group
+        # move it to another panel. or we shouldn't ?
+        files_in_curr_group = dict([
+            (i.file_name(), i) for i in
+            window.views_in_group(curr_group)
+        ])
+        if filename and filename in files_in_curr_group:
+            window.set_view_index(files_in_curr_group[filename], selected_group, 0)
 
     def _window_quick_panel_open_window(self, view, options):
         """ Shows the active `sublime.Window` quickpanel (dropdown) for
@@ -66,7 +111,7 @@ class BaseLookUpJediCommand(object):
         # Show the user a selection of filenames
         active_window.show_quick_panel(
             [self.prepare_option(o) for o in options],
-            self._jump_to_in_window, 
+            self._jump_to_in_window,
             on_highlight=partial(self._jump_to_in_window, transient=True))
 
     def prepare_option(self, option):

--- a/sublime_jedi/go_to.py
+++ b/sublime_jedi/go_to.py
@@ -57,6 +57,10 @@ class BaseLookUpJediCommand(object):
         flags = sublime.ENCODED_POSITION
         if transient:
             flags |= sublime.TRANSIENT
+            # sublime cant show quick panel with options on one panel and
+            # file's content in transient mode on another panel
+            # so dont do anything if its a requrest to show just options
+            return flags
         goto_layout = get_settings_param(self.view, 'sublime_goto_layout')
         if goto_layout == 'single-panel-transient' and not transient:
             flags |= sublime.TRANSIENT


### PR DESCRIPTION
add an option in settings so that user can define where to show goto definition source file
![2015-11-02 17 55 32](https://cloud.githubusercontent.com/assets/1183877/10886672/ec13f94e-818b-11e5-80fa-112beb139fff.png)
