### PR TITLE
Context menu

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -1,0 +1,18 @@
+[
+    {
+        "command": "sublime_jedi_goto",
+        "caption": "Go to Definition (Jedi)"
+    },
+    {
+        "command": "sublime_jedi_find_usages",
+        "caption": "Find Usages (Jedi)"
+    },
+    {
+        "command": "sublime_jedi_docstring",
+        "caption": "Show Docstring (Jedi)"
+    },
+    {
+        "command": "sublime_jedi_signature",
+        "caption": "Show Signature (Jedi)"
+    }
+]

--- a/sublime_jedi/go_to.py
+++ b/sublime_jedi/go_to.py
@@ -3,17 +3,11 @@ import sublime
 import sublime_plugin
 from functools import partial
 
-from .utils import to_relative_path, ask_daemon, is_python_scope
+from .utils import to_relative_path, ask_daemon, PythonCommandMixin
 from .settings import get_settings_param
 
 
-class BaseLookUpJediCommand(object):
-
-    def is_enabled(self):
-        """ command enable only for python source code """
-        if not is_python_scope(self.view, self.view.sel()[0].begin()):
-            return False
-        return True
+class BaseLookUpJediCommand(PythonCommandMixin):
 
     def _jump_to_in_window(self, filename, line_number=None, column_number=None, transient=False):
         """ Opens a new window and jumps to declaration if possible

--- a/sublime_jedi/helper.py
+++ b/sublime_jedi/helper.py
@@ -2,7 +2,7 @@
 import sublime
 import sublime_plugin
 
-from .utils import ask_daemon
+from .utils import ask_daemon, PythonCommandMixin
 
 
 class HelpMessageCommand(sublime_plugin.TextCommand):
@@ -12,7 +12,7 @@ class HelpMessageCommand(sublime_plugin.TextCommand):
         self.view.insert(edit, self.view.size(), docstring)
 
 
-class SublimeJediDocstring(sublime_plugin.TextCommand):
+class SublimeJediDocstring(PythonCommandMixin, sublime_plugin.TextCommand):
     """
     Show doctring in output panel
     """
@@ -32,7 +32,7 @@ class SublimeJediDocstring(sublime_plugin.TextCommand):
             sublime.status_message('Jedi: No results!')
 
 
-class SublimeJediSignature(sublime_plugin.TextCommand):
+class SublimeJediSignature(PythonCommandMixin, sublime_plugin.TextCommand):
     """
     Show signature in statusbar
     """

--- a/sublime_jedi/utils.py
+++ b/sublime_jedi/utils.py
@@ -261,6 +261,18 @@ def is_python_scope(view, location):
     return view.match_selector(location, "source.python - string - comment")
 
 
+class PythonCommandMixin(object):
+    """ A mixin that hides and disables command for non-python code """
+
+    def is_visible(self):
+        """ The command is visible only for python code """
+        return is_python_scope(self.view, self.view.sel()[0].begin())
+
+    def is_enabled(self):
+        """ The command is enabled only when it is visible """
+        return self.is_visible()
+
+
 def is_repl(view):
     """
     Is SublimeREPL ?


### PR DESCRIPTION
1. Not only disable, but also hide disabled "go to" commands for non-python syntax
2. Also, disable and hide documentation commands for non-python syntax
3. Add "go to" and documentation commands to context menu