### PR TITLE
Use mdpopups to display docstring popup when hovering text.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-jedic
 *.py[co]
-*.sublime
+*.sublime-project
+*.sublime-workspace
 *.ropeproject
 package-metadata.json
 .DS_Store

--- a/__init__.py
+++ b/__init__.py
@@ -1,9 +1,3 @@
-# fix absolute imports on ST3
-# TODO: remove
-#import sys
-#import os
-#sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
-
 try:
     from sublime_jedi import *
 except ImportError:

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,0 +1,11 @@
+{
+    "*": {
+        ">=3119": [
+            "markupsafe",
+            "mdpopups",
+            "pygments",
+            "python-jinja2",
+            "python-markdown"
+        ]
+    }
+}

--- a/sublime_jedi.sublime-settings
+++ b/sublime_jedi.sublime-settings
@@ -28,5 +28,10 @@
     // "single-panel-transient" - same as above but in transient mode
     // "two-panel" - opens a file in a split to two columns layout
     // "two-panel-transient" - same as above but in transient mode
-    "sublime_goto_layout": "single-panel"
+    "sublime_goto_layout": "single-panel",
+
+    // Use hover popup to display the docstring of a function.
+    // "true" - replace ST's goto defintion popup by jedi's docstring popup
+    // "false" - use ST's default goto definition popup
+    "enable_tooltip": true
 }

--- a/sublime_jedi/__init__.py
+++ b/sublime_jedi/__init__.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 from .completion import SublimeJediParamsAutocomplete, Autocomplete
 from .go_to import SublimeJediFindUsages, SublimeJediGoto
-from .helper import SublimeJediDocstring, SublimeJediSignature, HelpMessageCommand
+from .helper import (
+    SublimeJediDocstring, SublimeJediSignature, SublimeJediTooltip,
+    HelpMessageCommand
+)
 
 __all__ = [
     'SublimeJediGoto',
@@ -10,5 +13,6 @@ __all__ = [
     'Autocomplete',
     'SublimeJediDocstring',
     'SublimeJediSignature',
+    'SublimeJediTooltip',
     'HelpMessageCommand'
 ]

--- a/sublime_jedi/helper.py
+++ b/sublime_jedi/helper.py
@@ -18,7 +18,7 @@ except ImportError:
 
 from .console_logging import getLogger
 from .settings import get_plugin_settings
-from .utils import ask_daemon, PythonCommandMixin, is_sublime_v2
+from .utils import ask_daemon, PythonCommandMixin, is_sublime_v2, is_python_scope
 
 logger = getLogger(__name__)
 
@@ -187,7 +187,7 @@ class SublimeJediTooltip(sublime_plugin.EventListener):
             return
         if not self.enabled():
             return
-        if not view.match_selector(point, 'source.python - string - comment'):
+        if not is_python_scope(view, point):
             return
 
         def render(view, docstring):

--- a/sublime_jedi/helper.py
+++ b/sublime_jedi/helper.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 from functools import partial
 
-import html
-import re
-
 import sublime
 import sublime_plugin
 
@@ -87,9 +84,8 @@ class SublimeJediTooltip(sublime_plugin.EventListener):
 
     def on_hover(self, view, point, hover_zone):
         """Handle view.on_hover event."""
-        if not (hover_zone == sublime.HOVER_TEXT
-                and self.enabled()
-                and is_python_scope(view, point)):
+        if not (hover_zone == sublime.HOVER_TEXT and self.enabled() and
+                is_python_scope(view, point)):
             return
 
         ask_daemon(view,

--- a/sublime_jedi/helper.py
+++ b/sublime_jedi/helper.py
@@ -2,6 +2,8 @@
 import sublime
 import sublime_plugin
 
+import html
+
 try:
     # mdpopups needs 3119+ for wrapper_class, which diff popup relies on
     if int(sublime.version()) < 3119:
@@ -91,8 +93,7 @@ def docstring_tooltip(view, docstring, location=None):
 
 
 def markdown_html_builder(view, docstring):
-
-    doclines = docstring.split('\n')
+    doclines = html.escape(docstring, quote=False).split('\n')
     signature = doclines[0].strip()
     # first line is a signature if it contains parentheses
     if '(' in signature:
@@ -132,12 +133,12 @@ def markdown_html_builder(view, docstring):
 
 
 def simple_html_builder(docstring):
-    docstring = docstring.split('\n')
+    docstring = html.escape(docstring, quote=False).split('\n')
     docstring[0] = '<b>' + docstring[0] + '</b>'
-    html = '<body><p style="font-family: sans-serif;">{0}</p></body>'.format(
+    content = '<body><p style="font-family: sans-serif;">{0}</p></body>'.format(
        '<br />'.join(docstring)
     )
-    return html
+    return content
 
 
 class SublimeJediDocstring(PythonCommandMixin, sublime_plugin.TextCommand):

--- a/sublime_jedi/helper.py
+++ b/sublime_jedi/helper.py
@@ -70,6 +70,11 @@ class SublimeJediSignature(PythonCommandMixin, sublime_plugin.TextCommand):
 class SublimeJediTooltip(sublime_plugin.EventListener):
     """EventListener to show jedi's docstring tooltip."""
 
+    # display tooltip only for
+    #  - function/variable usage (variable.function, variable.other)
+    #  - function/variable definition (entity.name.class, entity.name.function)
+    SELECTOR = 'source.python & (variable | entity.name)'
+
     def enabled(self):
         """Check if hover popup is desired."""
         return get_plugin_settings().get('enable_tooltip', True)
@@ -85,7 +90,7 @@ class SublimeJediTooltip(sublime_plugin.EventListener):
     def on_hover(self, view, point, hover_zone):
         """Handle view.on_hover event."""
         if not (hover_zone == sublime.HOVER_TEXT and self.enabled() and
-                is_python_scope(view, point)):
+                view.match_selector(point, self.SELECTOR)):
             return
 
         ask_daemon(view,

--- a/sublime_jedi/helper.py
+++ b/sublime_jedi/helper.py
@@ -93,7 +93,7 @@ def docstring_tooltip(view, docstring, location=None):
 
 
 def markdown_html_builder(view, docstring):
-    doclines = html.escape(docstring, quote=False).split('\n')
+    doclines = docstring.split('\n')
     signature = doclines[0].strip()
     # first line is a signature if it contains parentheses
     if '(' in signature:
@@ -111,10 +111,11 @@ def markdown_html_builder(view, docstring):
         content = '```python\n{0} {1}\n```\n'.format(prefix, signature)
         # merge the rest of the docstring beginning with 3rd line
         # skip leading and tailing empty lines
-        content += '\n'.join(doclines[1:]).strip()
+        docstring = '\n'.join(doclines[1:]).strip()
+        content += html.escape(docstring, quote=False)
     else:
         # docstring does not contain signature
-        content = docstring
+        content = html.escape(docstring, quote=False)
 
     # preserve empty lines
     content = content.replace('\n\n', '\n\u00A0\n')

--- a/sublime_jedi/tooltips/__init__.py
+++ b/sublime_jedi/tooltips/__init__.py
@@ -13,7 +13,8 @@ def _guess_docstring_format(docstring):
     :rtype: sublime_jedi.tooltips.base.Tooltip
     """
     for tooltip_class in [MarkDownTooltip]:
-        return tooltip_class.guess(docstring) and tooltip_class()
+        if tooltip_class.guess(docstring):
+            return tooltip_class()
 
     return SimpleTooltip()
 

--- a/sublime_jedi/tooltips/__init__.py
+++ b/sublime_jedi/tooltips/__init__.py
@@ -26,5 +26,6 @@ def show_docstring_tooltip(view, docstring, location=None):
     :param docstring (basestring): python __doc__ string
     :param location (int): The text point where to create the popup
     """
-    tooltip = _guess_docstring_format(docstring)
-    tooltip.show_popup(view, docstring, location)
+    if docstring:
+        tooltip = _guess_docstring_format(docstring)
+        tooltip.show_popup(view, docstring, location)

--- a/sublime_jedi/tooltips/__init__.py
+++ b/sublime_jedi/tooltips/__init__.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+from .markdown import MarkDownTooltip
+from .simple import SimpleTooltip
+
+
+def _guess_docstring_format(docstring):
+    """Find proper tooltip class for docstring.
+
+    Docstrings could has different format, and we should pick a proper
+    tooltip for it.
+
+    :rtype: sublime_jedi.tooltips.base.Tooltip
+    """
+    for tooltip_class in [MarkDownTooltip]:
+        return tooltip_class.guess(docstring) and tooltip_class()
+
+    return SimpleTooltip()
+
+
+def show_docstring_tooltip(view, docstring, location=None):
+    """Show docstring in popup.
+
+    :param view (sublime.View): current active view
+    :param docstring (basestring): python __doc__ string
+    :param location (int): The text point where to create the popup
+    """
+    tooltip = _guess_docstring_format(docstring)
+    tooltip.show_popup(view, docstring, location)

--- a/sublime_jedi/tooltips/base.py
+++ b/sublime_jedi/tooltips/base.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+import abc
+
+
+class Tooltip:
+
+    __metaclass__ = abc.ABCMeta  # works for 2.7 and 3+
+
+    @classmethod
+    @abc.abstractmethod
+    def guess(cls, docstring):
+        """Check if tooltip can render the docstring.
+
+        :rtype: bool
+        """
+
+    @abc.abstractmethod
+    def show_popup(self, view, docstring, location=None):
+        """Show tooltip with docstring.
+
+        :rtype: NoneType
+        """

--- a/sublime_jedi/tooltips/markdown.py
+++ b/sublime_jedi/tooltips/markdown.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+import html
+
+import sublime
+
+try:
+    # mdpopups needs 3119+ for wrapper_class, which diff popup relies on
+    if int(sublime.version()) < 3119:
+        raise ImportError('Sublime Text 3119+ required.')
+
+    import mdpopups
+
+    # mdpopups 1.9.0+ is required because of wrapper_class and templates
+    if mdpopups.version() < (1, 9, 0):
+        raise ImportError('mdpopups 1.9.0+ required.')
+
+    _HAVE_MDPOPUPS = True
+except ImportError:
+    _HAVE_MDPOPUPS = False
+
+from .base import Tooltip
+
+
+class MarkDownTooltip(Tooltip):
+
+    @classmethod
+    def guess(cls, docstring):
+        return _HAVE_MDPOPUPS
+
+    def _get_style(self):
+        css = """
+            body {
+                margin: 6px;
+            }
+            div.mdpopups {
+                margin: 0;
+                padding: 0;
+            }
+            .jedi h6 {
+                font-weight: bold;
+                color: var(--bluish);
+            }
+        """
+        return css
+
+    def _build_html(self, view, docstring):
+        """ Convert python docstring to text ready to show in popup.
+        
+        :param view: sublime text view object
+        :param docstring: python docstring as a string
+        """
+        doclines = docstring.split('\n')
+        signature = doclines[0].strip()
+        # first line is a signature if it contains parentheses
+        if '(' in signature:
+
+            def is_class(string):
+                """Check whether string contains a class or function signature."""
+                for c in string:
+                    if c != '_':
+                        break
+                return c.isupper()
+
+            # a hackish way to determine whether it is a class or function
+            prefix = 'class' if is_class(signature) else 'def'
+            # highlight signature
+            content = '```python\n{0} {1}\n```\n'.format(prefix, signature)
+            # merge the rest of the docstring beginning with 3rd line
+            # skip leading and tailing empty lines
+            docstring = '\n'.join(doclines[1:]).strip()
+            content += html.escape(docstring, quote=False)
+        else:
+            # docstring does not contain signature
+            content = html.escape(docstring, quote=False)
+
+        # preserve empty lines
+        content = content.replace('\n\n', '\n\u00A0\n')
+        # preserve whitespace
+        content = content.replace('  ', '\u00A0\u00A0')
+        # convert markdown to html
+        content = mdpopups.md2html(view, content)
+        # highlight headlines ( Google Python Style Guide )
+        keywords = (
+            'Args:', 'Arguments:', 'Attributes:', 'Example:', 'Examples:', 'Note:',
+            'Raises:', 'Returns:', 'Yields:')
+        for keyword in keywords:
+            content = content.replace(
+                keyword + '<br />', '<h6>' + keyword + '</h6>')
+        return content
+
+    def show_popup(self, view, docstring, location=None):
+        if location is None:
+            location = view.sel()[0].begin()
+
+        mdpopups.show_popup(
+            view=view,
+            content=self._build_html(view, docstring),
+            location=location,
+            max_width=800,
+            md=True,
+            css=self._get_style(),
+            wrapper_class='jedi',
+            flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY)
+

--- a/sublime_jedi/tooltips/markdown.py
+++ b/sublime_jedi/tooltips/markdown.py
@@ -51,7 +51,7 @@ class MarkDownTooltip(Tooltip):
 
         :returns: None string or the prefixed signature
         """
-        pattern = '^([\w\.]+\.)?(\w+)\('
+        pattern = '^([\w\. \t]+\.[ \t]*)?(\w+)\('
         match = re.match(pattern, signature)
 
         if not match:
@@ -59,7 +59,9 @@ class MarkDownTooltip(Tooltip):
 
         # lower case built-in types
         path, func = match.groups()
-        types = ('dict', 'int', 'list', 'tuple', 'str', 'set', 'frozenset')
+        types = (
+            'basestring', 'unicode', 'byte', 'dict', 'float', 'int',
+            'list', 'tuple', 'str', 'set', 'frozenset')
         if any(func.startswith(s) for s in types):
             prefix = ''
         else:
@@ -112,7 +114,7 @@ class MarkDownTooltip(Tooltip):
             view=view,
             content=self._build_html(view, docstring),
             location=location,
-            max_width=800,
+            max_width=int(view.viewport_extent()[0]),
             md=True,
             css=self._get_style(),
             wrapper_class='jedi',

--- a/sublime_jedi/tooltips/markdown.py
+++ b/sublime_jedi/tooltips/markdown.py
@@ -69,8 +69,8 @@ class MarkDownTooltip(Tooltip):
         return prefix + signature
 
     def _build_html(self, view, docstring):
-        """ Convert python docstring to text ready to show in popup.
-        
+        """Convert python docstring to text ready to show in popup.
+
         :param view: sublime text view object
         :param docstring: python docstring as a string
         """
@@ -97,8 +97,8 @@ class MarkDownTooltip(Tooltip):
         content = mdpopups.md2html(view, content)
         # highlight headlines ( Google Python Style Guide )
         keywords = (
-            'Args:', 'Arguments:', 'Attributes:', 'Example:', 'Examples:', 'Note:',
-            'Raises:', 'Returns:', 'Yields:')
+            'Args:', 'Arguments:', 'Attributes:', 'Example:', 'Examples:',
+            'Note:', 'Raises:', 'Returns:', 'Yields:')
         for keyword in keywords:
             content = content.replace(
                 keyword + '<br />', '<h6>' + keyword + '</h6>')
@@ -117,4 +117,3 @@ class MarkDownTooltip(Tooltip):
             css=self._get_style(),
             wrapper_class='jedi',
             flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY)
-

--- a/sublime_jedi/tooltips/simple.py
+++ b/sublime_jedi/tooltips/simple.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+import html
+
+from .base import Tooltip
+
+
+class SimpleTooltip(Tooltip):
+
+    @classmethod
+    def guess(cls, docstring):
+        return True
+
+    def _build_html(self, docstring):
+        docstring = html.escape(docstring, quote=False).split('\n')
+        docstring[0] = '<b>' + docstring[0] + '</b>'
+        content = '<body><p style="font-family: sans-serif;">{0}</p></body>'.format(
+           '<br />'.join(docstring)
+        )
+        return content
+
+    def show_popup(self, view, docstring, location=None):
+        if location is None:
+            location = view.sel()[0].begin()
+
+        content = self._build_html(docstring)
+        view.show_popup(content, location=location, max_width=512)


### PR DESCRIPTION
How about a popup to display the signature and docstring triggered by hovering a function?

Here is a possible approach.

It makes use of mdpopups to highlight the signature using the current color scheme. The rest of the docstring is handled as markdown. Finally some maybe common headlines are highlighted.

If mdpopups is not available, rendering falls back to simple html creation.

If "enable_tooltip" is set to true in jedi's settings, the default goto definition tooltip is disabled for python sources in order to avoid fighting.