### PR TITLE
Improve order of suggestions in auto-completion.

### DIFF
--- a/sublime_jedi/completion.py
+++ b/sublime_jedi/completion.py
@@ -159,7 +159,7 @@ class Autocomplete(sublime_plugin.EventListener):
                     self.completions,
                     key=lambda x: (
                         -buffer.count(x[1]),  # frequency in the text
-                        len(x[1]) - len(x[1].strip('_')),  # now many undescores
+                        len(x[1]) - len(x[1].strip('_')),  # how many undescores
                         x[1]  # alphabetically
                     )
                 )

--- a/sublime_jedi/completion.py
+++ b/sublime_jedi/completion.py
@@ -153,9 +153,18 @@ class Autocomplete(sublime_plugin.EventListener):
             self.is_completion_ready = None
 
             if self.completions:
-                cplns = [tuple(i) for i in self.completions]
+                # sort completions by frequency in document
+                buffer = view.substr(sublime.Region(0, view.size()))
+                cplns = sorted(
+                    self.completions,
+                    key=lambda x: (
+                        -buffer.count(x[1]),  # frequency in the text
+                        len(x[1]) - len(x[1].strip('_')),  # now many undescores
+                        x[1]  # alphabetically
+                    )
+                )
+                cplns = [tuple(x) for x in cplns]
                 self.completions = []
-
                 if completion_mode in ('default', 'jedi'):
                     return cplns, PLUGIN_ONLY_COMPLETION
                 return cplns


### PR DESCRIPTION
Right now the order of the auto-completion suggestions is based on how exposed a name is and then in alphabetical order. Example:

```
- a
- b
- _a
- _b
```

This PR sorts the suggestions of auto-completion ordering first by how frequently a name appears in the current buffer, then by how public it is, and then alphabetically.

So if `_a` is the most mentioned of the suggestions in the current file then it goes to first place in the completion list.

I encourage you to test this branch while working, you will feel the difference :wink: 

Take a look here in the file I changed, notice how `completions` and `is_completion_ready` are on the top of the list and `on_query_completions` is in the bottom because is a method that is not called in this file.

![c1](https://user-images.githubusercontent.com/6555851/28749298-d9e1abf0-74c2-11e7-89f0-b3f542b0935b.png)

![c2](https://user-images.githubusercontent.com/6555851/28749299-e13579c2-74c2-11e7-8465-defed011fe67.png)

