### PR TITLE
Added support for hanging indentation of args in the signature popup

### DIFF
--- a/sublime_jedi/tooltips/markdown.py
+++ b/sublime_jedi/tooltips/markdown.py
@@ -79,7 +79,10 @@ class MarkDownTooltip(Tooltip):
             prefix = 'class ' if func.lstrip('_')[0].isupper() else 'def '
 
         # handle hanging indentation of arguments
-        clean_args = ''.join(args.split()).replace(',',', ')
+        clean_args = ''.join(
+            [each.group() for each in re.finditer(
+                '[^\s"\']+|"([^"]*)"|\'([^\']*)', args)]
+        ).replace(',', ', ')
         args_length_difference = len(args) - len(clean_args)
         # join signature
         signature = ''.join(

--- a/sublime_jedi/tooltips/markdown.py
+++ b/sublime_jedi/tooltips/markdown.py
@@ -78,14 +78,18 @@ class MarkDownTooltip(Tooltip):
         else:
             prefix = 'class ' if func.lstrip('_')[0].isupper() else 'def '
 
+        # handle hanging indentation of arguments
+        clean_args = ''.join(args.split()).replace(',',', ')
+        args_length_difference = len(args) - len(clean_args)
         # join signature
         signature = ''.join(
-            (prefix, path or '', func or '', args or '', note or ''))
+            (prefix, path or '', func or '', clean_args or '', note or ''))
+        signature_length = len(signature) + args_length_difference
         # Signature may span multiple lines which need to be merged to one.
         signature = signature.replace('\n', ' ')
         # Everything after the signature is docstring
         docstring = docstring[
-            len(signature) + len(comment or '') - len(prefix):] or ''
+            signature_length + len(comment or '') - len(prefix):] or ''
         return (signature, docstring.strip())
 
     def _build_html(self, view, docstring):


### PR DESCRIPTION
Hi @srusskih,

Similar to #227 and #229, I noticed the function signature in the markdown popup doesn't behave well with hanging indentation of arguments.

To overcome this, I have used the `''.join(args.split())` method to remove spaces, but instead of using `split()` I had to use a regular expression (*which I got from this [answer at StackOverflow](https://stackoverflow.com/a/366532/3601865)*), in order to respect spaces inside string default values.

Additionally, I've added a `.replace(',', ', ')` function to bring back the spaces between the arguments.

This is my first ever PR, so please feel free to flag up issues and/or offer guidance.

Thank you!

### Example
![sublimejedi_hanging_docstring_fix](https://user-images.githubusercontent.com/10420664/35768788-794f0668-08f9-11e8-8453-5a4e9203a8dc.png)
