### PR TITLE
Alow for using a different python_interpreter without a virtualenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,7 @@ clean:
 # will build a sublime package
 build: clean
 	zip -r SublimeJEDI.sublime-package `ls` -x .git SublimeJEDI.sublime-package *.pyc
+
+
+dev_install_mac:
+	ln -s "${PWD}" ~/Library/Application\ Support/Sublime\ Text\ 3/Packages/

--- a/sublime_jedi/utils.py
+++ b/sublime_jedi/utils.py
@@ -72,8 +72,9 @@ class Daemon(object):
             self.env = environment.create_environment(python_virtualenv,
                                                       safe=False)
         elif python_interpreter:
-            self.env = environment.create_environment(
+            self.env = environment.Environment(
                 environment._get_python_prefix(python_interpreter),
+                python_interpreter
             )
         else:
             self.env = jedi.get_default_environment()


### PR DESCRIPTION
fix for #250 

Instead of create jedi environment with suggested way via `create_environment` we should create `Environment` by ourself to use "custom" python interpreters like Maya