### PR TITLE
Pass location by name every time (QuickFix for #246)

### DIFF
--- a/sublime_jedi/completion.py
+++ b/sublime_jedi/completion.py
@@ -39,7 +39,12 @@ class SublimeJediParamsAutocomplete(sublime_plugin.TextCommand):
         #     return
 
         if get_settings(self.view)['complete_funcargs']:
-            ask_daemon(self.view, self.show_template, 'funcargs', self.view.sel()[0].end())
+            ask_daemon(
+                self.view,
+                self.show_template,
+                'funcargs',
+                location=self.view.sel()[0].end()
+            )
 
     @property
     def auto_match_enabled(self):
@@ -173,9 +178,16 @@ class Autocomplete(sublime_plugin.EventListener):
 
         if self.is_completion_ready is None:
             if completion_mode == 'all':
-                self.completions = self._get_default_completions(view, prefix, locations[0])
+                self.completions = self._get_default_completions(
+                    view, prefix, location=locations[0]
+                )
 
-            ask_daemon(view, self._show_completions, 'autocomplete', locations[0])
+            ask_daemon(
+                view,
+                self._show_completions,
+                'autocomplete',
+                location=locations[0]
+            )
             self.is_completion_ready = False
 
         view.run_command("hide_auto_complete")

--- a/sublime_jedi/go_to.py
+++ b/sublime_jedi/go_to.py
@@ -130,7 +130,7 @@ class SublimeJediGoto(BaseLookUpJediCommand, sublime_plugin.TextCommand):
             self.view,
             self.handle_definitions,
             'goto',
-            {'follow_imports': follow_imports},
+            ask_kwargs={'follow_imports': follow_imports},
         )
 
     def handle_definitions(self, view, defns):

--- a/sublime_jedi/helper.py
+++ b/sublime_jedi/helper.py
@@ -104,4 +104,4 @@ class SublimeJediTooltip(sublime_plugin.EventListener):
         ask_daemon(view,
                    partial(show_docstring_tooltip, location=point),
                    'docstring',
-                   point)
+                   location=point)


### PR DESCRIPTION
I assumed `location` was passed by name every time. It was not.
If is not passed by name then it replaces sometime the request `kwargs`.