### PR TITLE
Update jedi to v0.13.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ _get_dependency:
 dependencies:
 	rm -rf dependencies/
 	mkdir dependencies/
-	$(MAKE) _get_dependency -e REPO=https://github.com/davidhalter/jedi -e TAG=v0.13.1 -e TARGET=jedi
+	$(MAKE) _get_dependency -e REPO=https://github.com/davidhalter/jedi -e TAG=v0.13.2 -e TARGET=jedi
 	$(MAKE) _get_dependency -e REPO=https://github.com/davidhalter/parso -e TAG=v0.3.1 -e TARGET=parso
 	patch --dry-run -p0 < jedi_0.13.x.patch
 	patch -p0 < jedi_0.13.x.patch

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,20 @@
-define get_dependency =
-	git clone $(2) dep
-	cd dep; git checkout $(3)
-	mv dep/$(1) dependencies/
-	rm -rf dep
-endef
-
-
 dummy:
 	exit 0
 
+_get_dependency:
+	git clone $(REPO) dep
+	cd dep; git checkout $(TAG)
+	mv dep/$(TARGET) dependencies/
+	rm -rf dep
+
+.PHONY: dependencies
 dependencies:
 	rm -rf dependencies/
 	mkdir dependencies/
-	$(call get_dependency,jedi,https://github.com/davidhalter/jedi,v0.13.1)
-	$(call get_dependency,parso,https://github.com/davidhalter/parso,v0.3.1)
+	$(MAKE) _get_dependency -e REPO=https://github.com/davidhalter/jedi -e TAG=v0.13.1 -e TARGET=jedi
+	$(MAKE) _get_dependency -e REPO=https://github.com/davidhalter/parso -e TAG=v0.3.1 -e TARGET=parso
+	patch --dry-run -p0 < jedi_0.13.x.patch
+	patch -p0 < jedi_0.13.x.patch
 
 clean:
 	find . -name '*.pyc' -delete

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ dummy:
 dependencies:
 	rm -rf dependencies/
 	mkdir dependencies/
-	$(call get_dependency,jedi,https://github.com/davidhalter/jedi,v0.12.1)
+	$(call get_dependency,jedi,https://github.com/davidhalter/jedi,v0.13.1)
 	$(call get_dependency,parso,https://github.com/davidhalter/parso,v0.3.1)
 
 clean:

--- a/dependencies/jedi/__init__.py
+++ b/dependencies/jedi/__init__.py
@@ -36,7 +36,7 @@ As you see Jedi is pretty simple and allows you to concentrate on writing a
 good text editor, while still having very good IDE features for Python.
 """
 
-__version__ = '0.13.1'
+__version__ = '0.13.2'
 
 from jedi.api import Script, Interpreter, set_debug_function, \
     preload_module, names

--- a/dependencies/jedi/__init__.py
+++ b/dependencies/jedi/__init__.py
@@ -23,7 +23,7 @@ example for the autocompletion feature:
 ... datetime.da'''
 >>> script = jedi.Script(source, 3, len('datetime.da'), 'example.py')
 >>> script
-<Script: 'example.py'>
+<Script: 'example.py' ...>
 >>> completions = script.completions()
 >>> completions                                         #doctest: +ELLIPSIS
 [<Completion: date>, <Completion: datetime>, ...]
@@ -36,7 +36,7 @@ As you see Jedi is pretty simple and allows you to concentrate on writing a
 good text editor, while still having very good IDE features for Python.
 """
 
-__version__ = '0.12.1'
+__version__ = '0.13.1'
 
 from jedi.api import Script, Interpreter, set_debug_function, \
     preload_module, names

--- a/dependencies/jedi/_compatibility.py
+++ b/dependencies/jedi/_compatibility.py
@@ -150,6 +150,7 @@ def find_module_pre_py34(string, path=None, full_name=None, is_global_search=Tru
 
 
 find_module = find_module_py34 if is_py3 else find_module_pre_py34
+find_module = find_module_py33 if py_version == 33 else find_module
 find_module.__doc__ = """
 Provides information about a module.
 

--- a/dependencies/jedi/api/__init__.py
+++ b/dependencies/jedi/api/__init__.py
@@ -11,6 +11,7 @@ arguments.
 """
 import os
 import sys
+import warnings
 
 import parso
 from parso.python import tree
@@ -74,9 +75,6 @@ class Script(object):
     :param encoding: The encoding of ``source``, if it is not a
         ``unicode`` object (default ``'utf-8'``).
     :type encoding: str
-    :param source_encoding: The encoding of ``source``, if it is not a
-        ``unicode`` object (default ``'utf-8'``).
-    :type encoding: str
     :param sys_path: ``sys.path`` to use during analysis of the script
     :type sys_path: list
     :param environment: TODO
@@ -114,9 +112,10 @@ class Script(object):
         self._module_node, source = self._evaluator.parse_and_get_code(
             code=source,
             path=self.path,
+            encoding=encoding,
             cache=False,  # No disk cache, because the current script often changes.
-            diff_cache=True,
-            cache_path=settings.cache_directory
+            diff_cache=settings.fast_parser,
+            cache_path=settings.cache_directory,
         )
         debug.speed('parsed')
         self._code_lines = parso.split_lines(source, keepends=True)
@@ -134,7 +133,9 @@ class Script(object):
 
         column = line_len if column is None else column
         if not (0 <= column <= line_len):
-            raise ValueError('`column` parameter is not in a valid range.')
+            raise ValueError('`column` parameter (%d) is not in a valid range '
+                             '(0-%d) for line %d (%r).' % (
+                                 column, line_len, line, line_string))
         self._pos = line, column
         self._path = path
 
@@ -144,9 +145,9 @@ class Script(object):
     def _get_module(self):
         name = '__main__'
         if self.path is not None:
-            n = dotted_path_in_sys_path(self._evaluator.get_sys_path(), self.path)
-            if n is not None:
-                name = n
+            import_names = dotted_path_in_sys_path(self._evaluator.get_sys_path(), self.path)
+            if import_names is not None:
+                name = '.'.join(import_names)
 
         module = ModuleContext(
             self._evaluator, self._module_node, self.path,
@@ -156,7 +157,11 @@ class Script(object):
         return module
 
     def __repr__(self):
-        return '<%s: %s>' % (self.__class__.__name__, repr(self._orig_path))
+        return '<%s: %s %r>' % (
+            self.__class__.__name__,
+            repr(self._orig_path),
+            self._evaluator.environment,
+        )
 
     def completions(self):
         """
@@ -172,6 +177,24 @@ class Script(object):
             self._pos, self.call_signatures
         )
         completions = completion.completions()
+
+        def iter_import_completions():
+            for c in completions:
+                tree_name = c._name.tree_name
+                if tree_name is None:
+                    continue
+                definition = tree_name.get_definition()
+                if definition is not None \
+                        and definition.type in ('import_name', 'import_from'):
+                    yield c
+
+        if len(list(iter_import_completions())) > 10:
+            # For now disable completions if there's a lot of imports that
+            # might potentially be resolved. This is the case for tensorflow
+            # and has been fixed for it. This is obviously temporary until we
+            # have a better solution.
+            self._evaluator.infer_enabled = False
+
         debug.speed('completions end')
         return completions
 
@@ -203,20 +226,33 @@ class Script(object):
         # the API.
         return helpers.sorted_definitions(set(defs))
 
-    def goto_assignments(self, follow_imports=False):
+    def goto_assignments(self, follow_imports=False, follow_builtin_imports=False):
         """
         Return the first definition found, while optionally following imports.
         Multiple objects may be returned, because Python itself is a
         dynamic language, which means depending on an option you can have two
         different versions of a function.
 
+        :param follow_imports: The goto call will follow imports.
+        :param follow_builtin_imports: If follow_imports is True will decide if
+            it follow builtin imports.
         :rtype: list of :class:`classes.Definition`
         """
         def filter_follow_imports(names, check):
             for name in names:
                 if check(name):
-                    for result in filter_follow_imports(name.goto(), check):
-                        yield result
+                    new_names = list(filter_follow_imports(name.goto(), check))
+                    found_builtin = False
+                    if follow_builtin_imports:
+                        for new_name in new_names:
+                            if new_name.start_pos is None:
+                                found_builtin = True
+
+                    if found_builtin and not isinstance(name, imports.SubModuleName):
+                        yield name
+                    else:
+                        for new_name in new_names:
+                            yield new_name
                 else:
                     yield name
 
@@ -238,7 +274,7 @@ class Script(object):
         defs = [classes.Definition(self._evaluator, d) for d in set(names)]
         return helpers.sorted_definitions(defs)
 
-    def usages(self, additional_module_paths=()):
+    def usages(self, additional_module_paths=(), **kwargs):
         """
         Return :class:`classes.Definition` objects, which contain all
         names that point to the definition of the name under the cursor. This
@@ -247,17 +283,31 @@ class Script(object):
 
         .. todo:: Implement additional_module_paths
 
+        :param additional_module_paths: Deprecated, never ever worked.
+        :param include_builtins: Default True, checks if a usage is a builtin
+            (e.g. ``sys``) and in that case does not return it.
         :rtype: list of :class:`classes.Definition`
         """
-        tree_name = self._module_node.get_name_of_position(self._pos)
-        if tree_name is None:
-            # Must be syntax
-            return []
+        if additional_module_paths:
+            warnings.warn(
+                "Deprecated since version 0.12.0. This never even worked, just ignore it.",
+                DeprecationWarning,
+                stacklevel=2
+            )
 
-        names = usages.usages(self._get_module(), tree_name)
+        def _usages(include_builtins=True):
+            tree_name = self._module_node.get_name_of_position(self._pos)
+            if tree_name is None:
+                # Must be syntax
+                return []
 
-        definitions = [classes.Definition(self._evaluator, n) for n in names]
-        return helpers.sorted_definitions(definitions)
+            names = usages.usages(self._get_module(), tree_name)
+
+            definitions = [classes.Definition(self._evaluator, n) for n in names]
+            if not include_builtins:
+                definitions = [d for d in definitions if not d.in_builtin_module()]
+            return helpers.sorted_definitions(definitions)
+        return _usages(**kwargs)
 
     def call_signatures(self):
         """

--- a/dependencies/jedi/api/classes.py
+++ b/dependencies/jedi/api/classes.py
@@ -14,7 +14,7 @@ from jedi.evaluate import imports
 from jedi.evaluate import compiled
 from jedi.evaluate.imports import ImportName
 from jedi.evaluate.context import instance
-from jedi.evaluate.context import ClassContext, FunctionContext, FunctionExecutionContext
+from jedi.evaluate.context import ClassContext, FunctionExecutionContext
 from jedi.api.keywords import KeywordName
 
 
@@ -353,10 +353,7 @@ class BaseDefinition(object):
             return None
 
         if isinstance(context, FunctionExecutionContext):
-            # TODO the function context should be a part of the function
-            # execution context.
-            context = FunctionContext(
-                self._evaluator, context.parent_context, context.tree_node)
+            context = context.function_context
         return Definition(self._evaluator, context.name)
 
     def __repr__(self):
@@ -536,9 +533,9 @@ class Definition(BaseDefinition):
         # here.
         txt = definition.get_code(include_prefix=False)
         # Delete comments:
-        txt = re.sub('#[^\n]+\n', ' ', txt)
+        txt = re.sub(r'#[^\n]+\n', ' ', txt)
         # Delete multi spaces/newlines
-        txt = re.sub('\s+', ' ', txt).strip()
+        txt = re.sub(r'\s+', ' ', txt).strip()
         return txt
 
     @property
@@ -638,9 +635,18 @@ class CallSignature(Definition):
         """
         return self._bracket_start_pos
 
+    @property
+    def _params_str(self):
+        return ', '.join([p.description[6:]
+                          for p in self.params])
+
     def __repr__(self):
-        return '<%s: %s index %s>' % \
-            (type(self).__name__, self._name.string_name, self.index)
+        return '<%s: %s index=%r params=[%s]>' % (
+            type(self).__name__,
+            self._name.string_name,
+            self._index,
+            self._params_str,
+        )
 
 
 class _Help(object):

--- a/dependencies/jedi/api/environment.py
+++ b/dependencies/jedi/api/environment.py
@@ -190,8 +190,9 @@ def get_default_environment():
 
 
 def get_cached_default_environment():
+    var = os.environ.get('VIRTUAL_ENV')
     environment = _get_cached_default_environment()
-    if environment.path != os.environ.get('VIRTUAL_ENV'):
+    if var and var != environment.path:
         _get_cached_default_environment.clear_cache()
         return _get_cached_default_environment()
     return environment

--- a/dependencies/jedi/api/environment.py
+++ b/dependencies/jedi/api/environment.py
@@ -3,23 +3,21 @@ Environments are a way to activate different Python versions or Virtualenvs for
 static analysis. The Python binary in that environment is going to be executed.
 """
 import os
-import re
 import sys
 import hashlib
 import filecmp
-from subprocess import PIPE
 from collections import namedtuple
 
-from jedi._compatibility import GeneralizedPopen, which
+from jedi._compatibility import highest_pickle_protocol, which
 from jedi.cache import memoize_method, time_cache
-from jedi.evaluate.compiled.subprocess import get_subprocess, \
+from jedi.evaluate.compiled.subprocess import CompiledSubprocess, \
     EvaluatorSameProcess, EvaluatorSubprocess
 
 import parso
 
 _VersionInfo = namedtuple('VersionInfo', 'major minor micro')
 
-_SUPPORTED_PYTHONS = ['3.6', '3.5', '3.4', '3.3', '2.7']
+_SUPPORTED_PYTHONS = ['3.7', '3.6', '3.5', '3.4', '3.3', '2.7']
 _SAFE_PATHS = ['/usr/bin', '/usr/local/bin']
 _CURRENT_VERSION = '%s.%s' % (sys.version_info.major, sys.version_info.minor)
 
@@ -46,49 +44,66 @@ class _BaseEnvironment(object):
             return self._hash
 
 
+def _get_info():
+    return (
+        sys.executable,
+        sys.prefix,
+        sys.version_info[:3],
+    )
+
+
 class Environment(_BaseEnvironment):
     """
     This class is supposed to be created by internal Jedi architecture. You
     should not create it directly. Please use create_environment or the other
     functions instead. It is then returned by that function.
     """
-    def __init__(self, path, executable):
-        self.path = os.path.abspath(path)
-        """
-        The path to an environment, matches ``sys.prefix``.
-        """
-        self.executable = os.path.abspath(executable)
+    _subprocess = None
+
+    def __init__(self, executable):
+        self._start_executable = executable
+        # Initialize the environment
+        self._get_subprocess()
+
+    def _get_subprocess(self):
+        if self._subprocess is not None and not self._subprocess.is_crashed:
+            return self._subprocess
+
+        try:
+            self._subprocess = CompiledSubprocess(self._start_executable)
+            info = self._subprocess._send(None, _get_info)
+        except Exception as exc:
+            raise InvalidPythonEnvironment(
+                "Could not get version information for %r: %r" % (
+                    self._start_executable,
+                    exc))
+
+        # Since it could change and might not be the same(?) as the one given,
+        # set it here.
+        self.executable = info[0]
         """
         The Python executable, matches ``sys.executable``.
         """
-        self.version_info = self._get_version()
+        self.path = info[1]
         """
-
+        The path to an environment, matches ``sys.prefix``.
+        """
+        self.version_info = _VersionInfo(*info[2])
+        """
         Like ``sys.version_info``. A tuple to show the current Environment's
         Python version.
         """
 
-    def _get_version(self):
-        try:
-            process = GeneralizedPopen([self.executable, '--version'], stdout=PIPE, stderr=PIPE)
-            stdout, stderr = process.communicate()
-            retcode = process.poll()
-            if retcode:
-                raise InvalidPythonEnvironment(
-                    "Exited with %d (stdout=%r, stderr=%r)" % (
-                        retcode, stdout, stderr))
-        except OSError as exc:
-            raise InvalidPythonEnvironment(
-                "Could not get version information: %r" % exc)
+        # py2 sends bytes via pickle apparently?!
+        if self.version_info.major == 2:
+            self.executable = self.executable.decode()
+            self.path = self.path.decode()
 
-        # Until Python 3.4 wthe version string is part of stderr, after that
-        # stdout.
-        output = stdout + stderr
-        match = re.match(br'Python (\d+)\.(\d+)\.(\d+)', output)
-        if match is None:
-            raise InvalidPythonEnvironment("--version not working")
+        # Adjust pickle protocol according to host and client version.
+        self._subprocess._pickle_protocol = highest_pickle_protocol([
+            sys.version_info, self.version_info])
 
-        return _VersionInfo(*[int(m) for m in match.groups()])
+        return self._subprocess
 
     def __repr__(self):
         version = '.'.join(str(i) for i in self.version_info)
@@ -96,9 +111,6 @@ class Environment(_BaseEnvironment):
 
     def get_evaluator_subprocess(self, evaluator):
         return EvaluatorSubprocess(evaluator, self._get_subprocess())
-
-    def _get_subprocess(self):
-        return get_subprocess(self.executable, self.version_info)
 
     @memoize_method
     def get_sys_path(self):
@@ -118,10 +130,9 @@ class Environment(_BaseEnvironment):
 
 class SameEnvironment(Environment):
     def __init__(self):
-        super(SameEnvironment, self).__init__(sys.prefix, sys.executable)
-
-    def _get_version(self):
-        return _VersionInfo(*sys.version_info[:3])
+        self._start_executable = self.executable = sys.executable
+        self.path = sys.prefix
+        self.version_info = _VersionInfo(*sys.version_info[:3])
 
 
 class InterpreterEnvironment(_BaseEnvironment):
@@ -136,13 +147,18 @@ class InterpreterEnvironment(_BaseEnvironment):
 
 
 def _get_virtual_env_from_var():
+    """Get virtualenv environment from VIRTUAL_ENV environment variable.
+
+    It uses `safe=False` with ``create_environment``, because the environment
+    variable is considered to be safe / controlled by the user solely.
+    """
     var = os.environ.get('VIRTUAL_ENV')
     if var is not None:
         if var == sys.prefix:
             return SameEnvironment()
 
         try:
-            return create_environment(var)
+            return create_environment(var, safe=False)
         except InvalidPythonEnvironment:
             pass
 
@@ -168,16 +184,21 @@ def get_default_environment():
     if virtual_env is not None:
         return virtual_env
 
-    for environment in find_system_environments():
-        return environment
-
-    # If no Python Environment is found, use the environment we're already
+    # If no VirtualEnv is found, use the environment we're already
     # using.
     return SameEnvironment()
 
 
-@time_cache(seconds=10 * 60)  # 10 Minutes
 def get_cached_default_environment():
+    environment = _get_cached_default_environment()
+    if environment.path != os.environ.get('VIRTUAL_ENV'):
+        _get_cached_default_environment.clear_cache()
+        return _get_cached_default_environment()
+    return environment
+
+
+@time_cache(seconds=10 * 60)  # 10 Minutes
+def _get_cached_default_environment():
     return get_default_environment()
 
 
@@ -222,7 +243,7 @@ def find_virtualenvs(paths=None, **kwargs):
 
                 try:
                     executable = _get_executable_path(path, safe=safe)
-                    yield Environment(path, executable)
+                    yield Environment(executable)
                 except InvalidPythonEnvironment:
                     pass
 
@@ -246,23 +267,6 @@ def find_system_environments():
             pass
 
 
-# TODO: the logic to find the Python prefix is much more complicated than that.
-# See Modules/getpath.c for UNIX and PC/getpathp.c for Windows in CPython's
-# source code. A solution would be to deduce it by running the Python
-# interpreter and printing the value of sys.prefix.
-def _get_python_prefix(executable):
-    if os.name != 'nt':
-        return os.path.dirname(os.path.dirname(executable))
-    landmark = os.path.join('Lib', 'os.py')
-    prefix = os.path.dirname(executable)
-    while prefix:
-        if os.path.join(prefix, landmark):
-            return prefix
-        prefix = os.path.dirname(prefix)
-    raise InvalidPythonEnvironment(
-        "Cannot find prefix of executable %s." % executable)
-
-
 # TODO: this function should probably return a list of environments since
 # multiple Python installations can be found on a system for the same version.
 def get_system_environment(version):
@@ -277,17 +281,17 @@ def get_system_environment(version):
     if exe:
         if exe == sys.executable:
             return SameEnvironment()
-        return Environment(_get_python_prefix(exe), exe)
+        return Environment(exe)
 
     if os.name == 'nt':
-        for prefix, exe in _get_executables_from_windows_registry(version):
-            return Environment(prefix, exe)
+        for exe in _get_executables_from_windows_registry(version):
+            return Environment(exe)
     raise InvalidPythonEnvironment("Cannot find executable python%s." % version)
 
 
 def create_environment(path, safe=True):
     """
-    Make it possible to manually create an environment by specifying a
+    Make it possible to manually create an Environment object by specifying a
     Virtualenv path or an executable path.
 
     :raises: :exc:`.InvalidPythonEnvironment`
@@ -295,8 +299,8 @@ def create_environment(path, safe=True):
     """
     if os.path.isfile(path):
         _assert_safe(path, safe)
-        return Environment(_get_python_prefix(path), path)
-    return Environment(path, _get_executable_path(path, safe=safe))
+        return Environment(path)
+    return Environment(_get_executable_path(path, safe=safe))
 
 
 def _get_executable_path(path, safe=True):
@@ -318,16 +322,16 @@ def _get_executable_path(path, safe=True):
 def _get_executables_from_windows_registry(version):
     # The winreg module is named _winreg on Python 2.
     try:
-      import winreg
+        import winreg
     except ImportError:
-      import _winreg as winreg
+        import _winreg as winreg
 
     # TODO: support Python Anaconda.
     sub_keys = [
-      r'SOFTWARE\Python\PythonCore\{version}\InstallPath',
-      r'SOFTWARE\Wow6432Node\Python\PythonCore\{version}\InstallPath',
-      r'SOFTWARE\Python\PythonCore\{version}-32\InstallPath',
-      r'SOFTWARE\Wow6432Node\Python\PythonCore\{version}-32\InstallPath'
+        r'SOFTWARE\Python\PythonCore\{version}\InstallPath',
+        r'SOFTWARE\Wow6432Node\Python\PythonCore\{version}\InstallPath',
+        r'SOFTWARE\Python\PythonCore\{version}-32\InstallPath',
+        r'SOFTWARE\Wow6432Node\Python\PythonCore\{version}-32\InstallPath'
     ]
     for root_key in [winreg.HKEY_CURRENT_USER, winreg.HKEY_LOCAL_MACHINE]:
         for sub_key in sub_keys:
@@ -337,7 +341,7 @@ def _get_executables_from_windows_registry(version):
                     prefix = winreg.QueryValueEx(key, '')[0]
                     exe = os.path.join(prefix, 'python.exe')
                     if os.path.isfile(exe):
-                        yield prefix, exe
+                        yield exe
             except WindowsError:
                 pass
 

--- a/dependencies/jedi/api/helpers.py
+++ b/dependencies/jedi/api/helpers.py
@@ -105,14 +105,17 @@ def get_stack_at_position(grammar, code_lines, module_node, pos):
         # TODO This is for now not an official parso API that exists purely
         #   for Jedi.
         tokens = grammar._tokenize(code)
-        for token_ in tokens:
-            if token_.string == safeword:
+        for token in tokens:
+            if token.string == safeword:
                 raise EndMarkerReached()
-            elif token_.prefix.endswith(safeword):
+            elif token.prefix.endswith(safeword):
                 # This happens with comments.
                 raise EndMarkerReached()
+            elif token.string.endswith(safeword):
+                yield token  # Probably an f-string literal that was not finished.
+                raise EndMarkerReached()
             else:
-                yield token_
+                yield token
 
     # The code might be indedented, just remove it.
     code = dedent(_get_code_for_stack(code_lines, module_node, pos))
@@ -166,7 +169,8 @@ def _get_index_and_key(nodes, position):
 
     if nodes_before:
         last = nodes_before[-1]
-        if last.type == 'argument' and last.children[1].end_pos <= position:
+        if last.type == 'argument' and last.children[1] == '=' \
+                and last.children[1].end_pos <= position:
             # Checked if the argument
             key_str = last.children[0].value
         elif last == '=':

--- a/dependencies/jedi/api/project.py
+++ b/dependencies/jedi/api/project.py
@@ -85,7 +85,7 @@ class Project(object):
         if environment is None:
             environment = self.get_environment()
 
-        sys_path = environment.get_sys_path()
+        sys_path = list(environment.get_sys_path())
         try:
             sys_path.remove('')
         except ValueError:
@@ -108,12 +108,7 @@ class Project(object):
             if evaluator.script_path is not None:
                 suffixed += discover_buildout_paths(evaluator, evaluator.script_path)
 
-                traversed = []
-                for parent in traverse_parents(evaluator.script_path):
-                    traversed.append(parent)
-                    if parent == self._path:
-                        # Don't go futher than the project path.
-                        break
+                traversed = list(traverse_parents(evaluator.script_path))
 
                 # AFAIK some libraries have imports like `foo.foo.bar`, which
                 # leads to the conclusion to by default prefer longer paths

--- a/dependencies/jedi/api/replstartup.py
+++ b/dependencies/jedi/api/replstartup.py
@@ -1,6 +1,8 @@
 """
 To use Jedi completion in Python interpreter, add the following in your shell
-setup (e.g., ``.bashrc``)::
+setup (e.g., ``.bashrc``). This works only on Linux/Mac, because readline is
+not available on Windows. If you still want Jedi autocompletion in your REPL,
+just use IPython instead::
 
     export PYTHONSTARTUP="$(python -m jedi repl)"
 

--- a/dependencies/jedi/cache.py
+++ b/dependencies/jedi/cache.py
@@ -126,6 +126,7 @@ def time_cache(seconds):
 
         wrapper.clear_cache = lambda: cache.clear()
         return wrapper
+
     return decorator
 
 

--- a/dependencies/jedi/debug.py
+++ b/dependencies/jedi/debug.py
@@ -2,16 +2,17 @@ from jedi._compatibility import encoding, is_py3, u
 import os
 import time
 
+_inited = False
+
+
 def _lazy_colorama_init():
     """
-    Lazily init colorama if necessary, not to screw up stdout is debug not
-    enabled.
+    Lazily init colorama if necessary, not to screw up stdout if debugging is
+    not enabled.
 
     This version of the function does nothing.
     """
-    pass
 
-_inited=False
 
 try:
     if os.name == 'nt':
@@ -21,7 +22,8 @@ try:
         # Use colorama for nicer console output.
         from colorama import Fore, init
         from colorama import initialise
-        def _lazy_colorama_init():
+
+        def _lazy_colorama_init():  # noqa: F811
             """
             Lazily init colorama if necessary, not to screw up stdout is
             debug not enabled.

--- a/dependencies/jedi/evaluate/base_context.py
+++ b/dependencies/jedi/evaluate/base_context.py
@@ -199,9 +199,10 @@ def iterate_contexts(contexts, contextualized_node=None, is_async=False):
 
 
 class TreeContext(Context):
-    def __init__(self, evaluator, parent_context=None):
+    def __init__(self, evaluator, parent_context, tree_node):
         super(TreeContext, self).__init__(evaluator, parent_context)
         self.predefined_names = {}
+        self.tree_node = tree_node
 
     def __repr__(self):
         return '<%s: %s>' % (self.__class__.__name__, self.tree_node)

--- a/dependencies/jedi/evaluate/compiled/__init__.py
+++ b/dependencies/jedi/evaluate/compiled/__init__.py
@@ -32,8 +32,12 @@ def get_string_context_set(evaluator):
     return builtin_from_name(evaluator, u'str').execute_evaluated()
 
 
-def load_module(evaluator, **kwargs):
-    access_path = evaluator.compiled_subprocess.load_module(**kwargs)
+def load_module(evaluator, dotted_name, **kwargs):
+    # Temporary, some tensorflow builtins cannot be loaded, so it's tried again
+    # and again and it's really slow.
+    if dotted_name.startswith('tensorflow.'):
+        return None
+    access_path = evaluator.compiled_subprocess.load_module(dotted_name=dotted_name, **kwargs)
     if access_path is None:
         return None
     return create_from_access_path(evaluator, access_path)

--- a/dependencies/jedi/evaluate/compiled/access.py
+++ b/dependencies/jedi/evaluate/compiled/access.py
@@ -5,8 +5,7 @@ from textwrap import dedent
 import operator as op
 from collections import namedtuple
 
-# note: backport of jedi==0.12.1 is_py34 decision
-from jedi._compatibility import unicode, is_py3, is_py35, builtins, \
+from jedi._compatibility import unicode, is_py3, py_version, builtins, \
     py_version, force_unicode, print_to_stderr
 from jedi.evaluate.compiled.getattr_static import getattr_static
 
@@ -34,8 +33,8 @@ if is_py3:
         types.MappingProxyType,
         types.SimpleNamespace,
     )
-    # note: backport of jedi==0.12.1 is_py34 decision
-    if is_py35:
+
+    if not py_version == 33:
         NOT_CLASS_TYPES += (types.DynamicClassAttribute,)
 
 

--- a/dependencies/jedi/evaluate/compiled/access.py
+++ b/dependencies/jedi/evaluate/compiled/access.py
@@ -5,11 +5,10 @@ from textwrap import dedent
 import operator as op
 from collections import namedtuple
 
-from jedi import debug
-from jedi._compatibility import unicode, is_py3, is_py34, builtins, \
+# note: backport of jedi==0.12.1 is_py34 decision
+from jedi._compatibility import unicode, is_py3, is_py35, builtins, \
     py_version, force_unicode, print_to_stderr
 from jedi.evaluate.compiled.getattr_static import getattr_static
-from jedi.evaluate.utils import dotted_from_fs_path
 
 
 MethodDescriptorType = type(str.replace)
@@ -33,9 +32,10 @@ NOT_CLASS_TYPES = (
 if is_py3:
     NOT_CLASS_TYPES += (
         types.MappingProxyType,
-        types.SimpleNamespace
+        types.SimpleNamespace,
     )
-    if is_py34:
+    # note: backport of jedi==0.12.1 is_py34 decision
+    if is_py35:
         NOT_CLASS_TYPES += (types.DynamicClassAttribute,)
 
 
@@ -137,20 +137,13 @@ def create_access(evaluator, obj):
     return evaluator.compiled_subprocess.get_or_create_access_handle(obj)
 
 
-def load_module(evaluator, path=None, name=None, sys_path=None):
-    if sys_path is None:
-        sys_path = list(evaluator.get_sys_path())
-    if path is not None:
-        dotted_path = dotted_from_fs_path(path, sys_path=sys_path)
-    else:
-        dotted_path = name
-
+def load_module(evaluator, dotted_name, sys_path):
     temp, sys.path = sys.path, sys_path
     try:
-        __import__(dotted_path)
+        __import__(dotted_name)
     except ImportError:
         # If a module is "corrupt" or not really a Python module or whatever.
-        debug.warning('Module %s not importable in path %s.', dotted_path, path)
+        print_to_stderr('Module %s not importable in path %s.' % (dotted_name, sys_path))
         return None
     except Exception:
         # Since __import__ pretty much makes code execution possible, just
@@ -163,7 +156,7 @@ def load_module(evaluator, path=None, name=None, sys_path=None):
 
     # Just access the cache after import, because of #59 as well as the very
     # complicated import structure of Python.
-    module = sys.modules[dotted_path]
+    module = sys.modules[dotted_name]
     return create_access_path(evaluator, module)
 
 
@@ -261,6 +254,9 @@ class DirectObjectAccess(object):
 
     def py__bases__(self):
         return [self._create_access_path(base) for base in self._obj.__bases__]
+
+    def py__path__(self):
+        return self._obj.__path__
 
     @_force_unicode_decorator
     def get_repr(self):
@@ -476,7 +472,7 @@ else:
 
 class _SPECIAL_OBJECTS(object):
     FUNCTION_CLASS = types.FunctionType
-    METHOD_CLASS = type(DirectObjectAccess.py__bool__)
+    BOUND_METHOD_CLASS = type(DirectObjectAccess(None, None).py__bool__)
     MODULE_CLASS = types.ModuleType
     GENERATOR_OBJECT = _a_generator(1.0)
     BUILTINS = builtins

--- a/dependencies/jedi/evaluate/compiled/context.py
+++ b/dependencies/jedi/evaluate/compiled/context.py
@@ -55,7 +55,7 @@ class CompiledObject(Context):
             return FunctionContext(
                 self.evaluator,
                 parent_context=self.parent_context,
-                funcdef=self.tree_node
+                tree_node=self.tree_node
             ).py__call__(params)
         if self.access_handle.is_class():
             from jedi.evaluate.context import CompiledInstance
@@ -80,6 +80,10 @@ class CompiledObject(Context):
             create_from_access_path(self.evaluator, access)
             for access in self.access_handle.py__bases__()
         )
+
+    @CheckAttribute
+    def py__path__(self):
+        return self.access_handle.py__path__()
 
     def py__bool__(self):
         return self.access_handle.py__bool__()
@@ -443,8 +447,11 @@ def create_from_name(evaluator, compiled_object, name):
         pass
 
     access = compiled_object.access_handle.getattr(name, default=None)
+    parent_context = compiled_object
+    if parent_context.is_class():
+        parent_context = parent_context.parent_context
     return create_cached_compiled_object(
-        evaluator, access, parent_context=compiled_object, faked=faked
+        evaluator, access, parent_context=parent_context, faked=faked
     )
 
 

--- a/dependencies/jedi/evaluate/compiled/mixed.py
+++ b/dependencies/jedi/evaluate/compiled/mixed.py
@@ -107,7 +107,7 @@ def _load_module(evaluator, path):
     module_node = evaluator.grammar.parse(
         path=path,
         cache=True,
-        diff_cache=True,
+        diff_cache=settings.fast_parser,
         cache_path=settings.cache_directory
     ).get_root_node()
     # python_module = inspect.getmodule(python_object)

--- a/dependencies/jedi/evaluate/compiled/subprocess/__init__.py
+++ b/dependencies/jedi/evaluate/compiled/subprocess/__init__.py
@@ -15,27 +15,41 @@ import errno
 import weakref
 import traceback
 from functools import partial
+from threading import Thread
+try:
+    from queue import Queue, Empty
+except ImportError:
+    from Queue import Queue, Empty  # python 2.7
 
 from jedi._compatibility import queue, is_py3, force_unicode, \
-    pickle_dump, pickle_load, highest_pickle_protocol, GeneralizedPopen
+    pickle_dump, pickle_load, GeneralizedPopen, print_to_stderr
+from jedi import debug
 from jedi.cache import memoize_method
 from jedi.evaluate.compiled.subprocess import functions
 from jedi.evaluate.compiled.access import DirectObjectAccess, AccessPath, \
     SignatureParam
 from jedi.api.exceptions import InternalError
 
-_subprocesses = {}
 
 _MAIN_PATH = os.path.join(os.path.dirname(__file__), '__main__.py')
 
 
-def get_subprocess(executable, version):
-    try:
-        return _subprocesses[executable]
-    except KeyError:
-        sub = _subprocesses[executable] = _CompiledSubprocess(executable,
-                                                              version)
-        return sub
+def _enqueue_output(out, queue):
+    for line in iter(out.readline, b''):
+        queue.put(line)
+    out.close()
+
+
+def _add_stderr_to_debug(stderr_queue):
+    while True:
+        # Try to do some error reporting from the subprocess and print its
+        # stderr contents.
+        try:
+            line = stderr_queue.get_nowait()
+            line = line.decode('utf-8', 'replace')
+            debug.warning('stderr output: %s' % line.rstrip('\n'))
+        except Empty:
+            break
 
 
 def _get_function(name):
@@ -119,30 +133,41 @@ class EvaluatorSubprocess(_EvaluatorProcess):
         return obj
 
     def __del__(self):
-        if self._used:
+        if self._used and not self._compiled_subprocess.is_crashed:
             self._compiled_subprocess.delete_evaluator(self._evaluator_id)
 
 
-class _CompiledSubprocess(object):
-    _crashed = False
+class CompiledSubprocess(object):
+    is_crashed = False
+    # Start with 2, gets set after _get_info.
+    _pickle_protocol = 2
 
-    def __init__(self, executable, version):
+    def __init__(self, executable):
         self._executable = executable
         self._evaluator_deletion_queue = queue.deque()
-        self._pickle_protocol = highest_pickle_protocol([sys.version_info,
-                                                         version])
+
+    def __repr__(self):
+        pid = os.getpid()
+        return '<%s _executable=%r, _pickle_protocol=%r, is_crashed=%r, pid=%r>' % (
+            self.__class__.__name__,
+            self._executable,
+            self._pickle_protocol,
+            self.is_crashed,
+            pid,
+        )
 
     @property
     @memoize_method
     def _process(self):
+        debug.dbg('Start environment subprocess %s', self._executable)
         parso_path = sys.modules['parso'].__file__
         args = (
             self._executable,
             _MAIN_PATH,
             os.path.dirname(os.path.dirname(parso_path)),
-            str(self._pickle_protocol)
+            '.'.join(str(x) for x in sys.version_info[:3]),
         )
-        return GeneralizedPopen(
+        process = GeneralizedPopen(
             args,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
@@ -151,6 +176,14 @@ class _CompiledSubprocess(object):
             # (this is already the case on Python 3).
             bufsize=-1
         )
+        self._stderr_queue = Queue()
+        self._stderr_thread = t = Thread(
+            target=_enqueue_output,
+            args=(process.stderr, self._stderr_queue)
+        )
+        t.daemon = True
+        t.start()
+        return process
 
     def run(self, evaluator, function, args=(), kwargs={}):
         # Delete old evaluators.
@@ -168,24 +201,23 @@ class _CompiledSubprocess(object):
     def get_sys_path(self):
         return self._send(None, functions.get_sys_path, (), {})
 
-    def kill(self):
-        self._crashed = True
+    def _kill(self):
+        self.is_crashed = True
         try:
-            subprocess = _subprocesses[self._executable]
-        except KeyError:
-            # Fine it was already removed from the cache.
+            self._process.kill()
+            self._process.wait()
+        except (AttributeError, TypeError):
+            # If the Python process is terminating, it will remove some modules
+            # earlier than others and in general it's unclear how to deal with
+            # that so we just ignore the exceptions here.
             pass
-        else:
-            # In the `!=` case there is already a new subprocess in place
-            # and we don't need to do anything here anymore.
-            if subprocess == self:
-                del _subprocesses[self._executable]
 
-        self._process.kill()
-        self._process.wait()
+    def __del__(self):
+        if not self.is_crashed:
+            self._kill()
 
     def _send(self, evaluator_id, function, args=(), kwargs={}):
-        if self._crashed:
+        if self.is_crashed:
             raise InternalError("The subprocess %s has crashed." % self._executable)
 
         if not is_py3:
@@ -202,7 +234,7 @@ class _CompiledSubprocess(object):
             if e.errno not in (errno.EPIPE, errno.EINVAL):
                 # Not a broken pipe
                 raise
-            self.kill()
+            self._kill()
             raise InternalError("The subprocess %s was killed. Maybe out of memory?"
                                 % self._executable)
 
@@ -210,16 +242,19 @@ class _CompiledSubprocess(object):
             is_exception, traceback, result = pickle_load(self._process.stdout)
         except EOFError as eof_error:
             try:
-                stderr = self._process.stderr.read()
+                stderr = self._process.stderr.read().decode('utf-8', 'replace')
             except Exception as exc:
                 stderr = '<empty/not available (%r)>' % exc
-            self.kill()
+            self._kill()
+            _add_stderr_to_debug(self._stderr_queue)
             raise InternalError(
                 "The subprocess %s has crashed (%r, stderr=%s)." % (
                     self._executable,
                     eof_error,
                     stderr,
                 ))
+
+        _add_stderr_to_debug(self._stderr_queue)
 
         if is_exception:
             # Replace the attribute error message with a the traceback. It's
@@ -284,11 +319,9 @@ class Listener(object):
 
     def listen(self):
         stdout = sys.stdout
-        # Mute stdout/stderr. Nobody should actually be able to write to those,
-        # because stdout is used for IPC and stderr will just be annoying if it
-        # leaks (on module imports).
+        # Mute stdout. Nobody should actually be able to write to it,
+        # because stdout is used for IPC.
         sys.stdout = open(os.devnull, 'w')
-        sys.stderr = open(os.devnull, 'w')
         stdin = sys.stdin
         if sys.version_info[0] > 2:
             stdout = stdout.buffer
@@ -304,9 +337,9 @@ class Listener(object):
             try:
                 payload = pickle_load(stdin)
             except EOFError:
-                # It looks like the parent process closed. Don't make a big fuss
-                # here and just exit.
-                exit(1)
+                # It looks like the parent process closed.
+                # Don't make a big fuss here and just exit.
+                exit(0)
             try:
                 result = False, None, self._run(*payload)
             except Exception as e:

--- a/dependencies/jedi/evaluate/compiled/subprocess/__main__.py
+++ b/dependencies/jedi/evaluate/compiled/subprocess/__main__.py
@@ -1,5 +1,5 @@
-import sys
 import os
+import sys
 
 
 def _get_paths():
@@ -45,7 +45,11 @@ else:
     load('jedi')
     from jedi.evaluate.compiled import subprocess  # NOQA
 
+from jedi._compatibility import highest_pickle_protocol  # noqa: E402
+
+
 # Retrieve the pickle protocol.
-pickle_protocol = int(sys.argv[2])
+host_sys_version = [int(x) for x in sys.argv[2].split('.')]
+pickle_protocol = highest_pickle_protocol([sys.version_info, host_sys_version])
 # And finally start the client.
-subprocess.Listener(pickle_protocol).listen()
+subprocess.Listener(pickle_protocol=pickle_protocol).listen()

--- a/dependencies/jedi/evaluate/context/function.py
+++ b/dependencies/jedi/evaluate/context/function.py
@@ -38,16 +38,8 @@ class LambdaName(AbstractNameDefinition):
         return ContextSet(self._lambda_context)
 
 
-class FunctionContext(use_metaclass(CachedMetaClass, TreeContext)):
-    """
-    Needed because of decorators. Decorators are evaluated here.
-    """
+class AbstractFunction(TreeContext):
     api_type = u'function'
-
-    def __init__(self, evaluator, parent_context, funcdef):
-        """ This should not be called directly """
-        super(FunctionContext, self).__init__(evaluator, parent_context)
-        self.tree_node = funcdef
 
     def get_filters(self, search_global, until_position=None, origin_scope=None):
         if search_global:
@@ -61,6 +53,24 @@ class FunctionContext(use_metaclass(CachedMetaClass, TreeContext)):
             scope = self.py__class__()
             for filter in scope.get_filters(search_global=False, origin_scope=origin_scope):
                 yield filter
+
+    def get_param_names(self):
+        function_execution = self.get_function_execution()
+        return [ParamName(function_execution, param.name)
+                for param in self.tree_node.get_params()]
+
+    @property
+    def name(self):
+        if self.tree_node.type == 'lambdef':
+            return LambdaName(self)
+        return ContextName(self, self.tree_node.name)
+
+    def get_function_execution(self, arguments=None):
+        raise NotImplementedError
+
+    def py__call__(self, arguments):
+        function_execution = self.get_function_execution(arguments)
+        return self.infer_function_execution(function_execution)
 
     def infer_function_execution(self, function_execution):
         """
@@ -84,35 +94,31 @@ class FunctionContext(use_metaclass(CachedMetaClass, TreeContext)):
             else:
                 return function_execution.get_return_values()
 
+    def py__name__(self):
+        return self.name.string_name
+
+
+class FunctionContext(use_metaclass(CachedMetaClass, AbstractFunction)):
+    """
+    Needed because of decorators. Decorators are evaluated here.
+    """
+    @classmethod
+    def from_context(cls, context, tree_node):
+        from jedi.evaluate.context import AbstractInstanceContext
+
+        while context.is_class() or isinstance(context, AbstractInstanceContext):
+            context = context.parent_context
+
+        return cls(context.evaluator, parent_context=context, tree_node=tree_node)
+
     def get_function_execution(self, arguments=None):
         if arguments is None:
             arguments = AnonymousArguments()
 
         return FunctionExecutionContext(self.evaluator, self.parent_context, self, arguments)
 
-    def py__call__(self, arguments):
-        function_execution = self.get_function_execution(arguments)
-        return self.infer_function_execution(function_execution)
-
     def py__class__(self):
-        # This differentiation is only necessary for Python2. Python3 does not
-        # use a different method class.
-        if isinstance(parser_utils.get_parent_scope(self.tree_node), tree.Class):
-            name = u'METHOD_CLASS'
-        else:
-            name = u'FUNCTION_CLASS'
-        return compiled.get_special_object(self.evaluator, name)
-
-    @property
-    def name(self):
-        if self.tree_node.type == 'lambdef':
-            return LambdaName(self)
-        return ContextName(self, self.tree_node.name)
-
-    def get_param_names(self):
-        function_execution = self.get_function_execution()
-        return [ParamName(function_execution, param.name)
-                for param in self.tree_node.get_params()]
+        return compiled.get_special_object(self.evaluator, u'FUNCTION_CLASS')
 
 
 class FunctionExecutionContext(TreeContext):
@@ -127,9 +133,12 @@ class FunctionExecutionContext(TreeContext):
     function_execution_filter = FunctionExecutionFilter
 
     def __init__(self, evaluator, parent_context, function_context, var_args):
-        super(FunctionExecutionContext, self).__init__(evaluator, parent_context)
+        super(FunctionExecutionContext, self).__init__(
+            evaluator,
+            parent_context,
+            function_context.tree_node,
+        )
         self.function_context = function_context
-        self.tree_node = function_context.tree_node
         self.var_args = var_args
 
     @evaluator_method_cache(default=NO_CONTEXTS)
@@ -240,5 +249,5 @@ class FunctionExecutionContext(TreeContext):
                                              origin_scope=origin_scope)
 
     @evaluator_method_cache()
-    def get_params(self):
-        return self.var_args.get_params(self)
+    def get_executed_params(self):
+        return self.var_args.get_executed_params(self)

--- a/dependencies/jedi/evaluate/context/iterable.py
+++ b/dependencies/jedi/evaluate/context/iterable.py
@@ -267,6 +267,11 @@ class DictComprehension(ComprehensionMixin, Sequence):
 
         return ContextSet(FakeSequence(self.evaluator, u'list', lazy_contexts))
 
+    def exact_key_items(self):
+        # NOTE: A smarter thing can probably done here to achieve better
+        # completions, but at least like this jedi doesn't crash
+        return []
+
 
 class GeneratorComprehension(ComprehensionMixin, GeneratorBase):
     pass

--- a/dependencies/jedi/evaluate/context/klass.py
+++ b/dependencies/jedi/evaluate/context/klass.py
@@ -38,11 +38,12 @@ py__doc__(include_call_signature:      Returns the docstring for a context.
 
 """
 from jedi._compatibility import use_metaclass
+from jedi.parser_utils import get_parent_scope
 from jedi.evaluate.cache import evaluator_method_cache, CachedMetaClass
 from jedi.evaluate import compiled
 from jedi.evaluate.lazy_context import LazyKnownContext
 from jedi.evaluate.filters import ParserTreeFilter, TreeNameDefinition, \
-    ContextName, AnonymousInstanceParamName
+    ContextName
 from jedi.evaluate.base_context import ContextSet, iterator_to_context_set, \
     TreeContext
 
@@ -58,9 +59,10 @@ def apply_py__get__(context, base_context):
 
 
 class ClassName(TreeNameDefinition):
-    def __init__(self, parent_context, tree_name, name_context):
+    def __init__(self, parent_context, tree_name, name_context, apply_decorators):
         super(ClassName, self).__init__(parent_context, tree_name)
         self._name_context = name_context
+        self._apply_decorators = apply_decorators
 
     @iterator_to_context_set
     def infer(self):
@@ -72,16 +74,45 @@ class ClassName(TreeNameDefinition):
             self.parent_context.evaluator, self._name_context, self.tree_name)
 
         for result_context in inferred:
-            for c in apply_py__get__(result_context, self.parent_context):
-                yield c
+            if self._apply_decorators:
+                for c in apply_py__get__(result_context, self.parent_context):
+                    yield c
+            else:
+                yield result_context
 
 
 class ClassFilter(ParserTreeFilter):
     name_class = ClassName
 
+    def __init__(self, *args, **kwargs):
+        self._is_instance = kwargs.pop('is_instance')  # Python 2 :/
+        super(ClassFilter, self).__init__(*args, **kwargs)
+
     def _convert_names(self, names):
-        return [self.name_class(self.context, name, self._node_context)
-                for name in names]
+        return [
+            self.name_class(
+                parent_context=self.context,
+                tree_name=name,
+                name_context=self._node_context,
+                apply_decorators=not self._is_instance,
+            ) for name in names
+        ]
+
+    def _equals_origin_scope(self):
+        node = self._origin_scope
+        while node is not None:
+            if node == self._parser_scope or node == self.context:
+                return True
+            node = get_parent_scope(node)
+        return False
+
+    def _access_possible(self, name):
+        return not name.value.startswith('__') or name.value.endswith('__') \
+            or self._equals_origin_scope()
+
+    def _filter(self, names):
+        names = super(ClassFilter, self)._filter(names)
+        return [name for name in names if self._access_possible(name)]
 
 
 class ClassContext(use_metaclass(CachedMetaClass, TreeContext)):
@@ -90,10 +121,6 @@ class ClassContext(use_metaclass(CachedMetaClass, TreeContext)):
     important for descriptors (if the descriptor methods are evaluated or not).
     """
     api_type = u'class'
-
-    def __init__(self, evaluator, parent_context, classdef):
-        super(ClassContext, self).__init__(evaluator, parent_context=parent_context)
-        self.tree_node = classdef
 
     @evaluator_method_cache(default=())
     def py__mro__(self):
@@ -148,11 +175,6 @@ class ClassContext(use_metaclass(CachedMetaClass, TreeContext)):
     def py__class__(self):
         return compiled.builtin_from_name(self.evaluator, u'type')
 
-    def get_params(self):
-        from jedi.evaluate.context import AnonymousInstance
-        anon = AnonymousInstance(self.evaluator, self.parent_context, self)
-        return [AnonymousInstanceParamName(anon, param.name) for param in self.funcdef.get_params()]
-
     def get_filters(self, search_global, until_position=None, origin_scope=None, is_instance=False):
         if search_global:
             yield ParserTreeFilter(
@@ -169,7 +191,9 @@ class ClassContext(use_metaclass(CachedMetaClass, TreeContext)):
                 else:
                     yield ClassFilter(
                         self.evaluator, self, node_context=cls,
-                        origin_scope=origin_scope)
+                        origin_scope=origin_scope,
+                        is_instance=is_instance
+                    )
 
     def is_class(self):
         return True

--- a/dependencies/jedi/evaluate/context/module.py
+++ b/dependencies/jedi/evaluate/context/module.py
@@ -43,8 +43,11 @@ class ModuleContext(TreeContext):
     parent_context = None
 
     def __init__(self, evaluator, module_node, path, code_lines):
-        super(ModuleContext, self).__init__(evaluator, parent_context=None)
-        self.tree_node = module_node
+        super(ModuleContext, self).__init__(
+            evaluator,
+            parent_context=None,
+            tree_node=module_node
+        )
         self._path = path
         self.code_lines = code_lines
 

--- a/dependencies/jedi/evaluate/context/namespace.py
+++ b/dependencies/jedi/evaluate/context/namespace.py
@@ -4,7 +4,7 @@ from itertools import chain
 from jedi.evaluate.cache import evaluator_method_cache
 from jedi.evaluate import imports
 from jedi.evaluate.filters import DictFilter, AbstractNameDefinition, ContextNameMixin
-from jedi.evaluate.base_context import TreeContext, ContextSet
+from jedi.evaluate.base_context import Context
 
 
 class ImplicitNSName(ContextNameMixin, AbstractNameDefinition):
@@ -17,7 +17,7 @@ class ImplicitNSName(ContextNameMixin, AbstractNameDefinition):
         self.string_name = string_name
 
 
-class ImplicitNamespaceContext(TreeContext):
+class ImplicitNamespaceContext(Context):
     """
     Provides support for implicit namespace packages
     """

--- a/dependencies/jedi/evaluate/docstrings.py
+++ b/dependencies/jedi/evaluate/docstrings.py
@@ -68,7 +68,7 @@ def _search_param_in_numpydocstr(docstr, param_str):
         return []
     for p_name, p_type, p_descr in params:
         if p_name == param_str:
-            m = re.match('([^,]+(,[^,]+)*?)(,[ ]*optional)?$', p_type)
+            m = re.match(r'([^,]+(,[^,]+)*?)(,[ ]*optional)?$', p_type)
             if m:
                 p_type = m.group(1)
             return list(_expand_typestr(p_type))
@@ -103,11 +103,11 @@ def _expand_typestr(type_str):
     Attempts to interpret the possible types in `type_str`
     """
     # Check if alternative types are specified with 'or'
-    if re.search('\\bor\\b', type_str):
+    if re.search(r'\bor\b', type_str):
         for t in type_str.split('or'):
             yield t.split('of')[0].strip()
     # Check if like "list of `type`" and set type to list
-    elif re.search('\\bof\\b', type_str):
+    elif re.search(r'\bof\b', type_str):
         yield type_str.split('of')[0]
     # Check if type has is a set of valid literal values eg: {'C', 'F', 'A'}
     elif type_str.startswith('{'):
@@ -194,7 +194,7 @@ def _evaluate_for_statement_string(module_context, string):
     if string is None:
         return []
 
-    for element in re.findall('((?:\w+\.)*\w+)\.', string):
+    for element in re.findall(r'((?:\w+\.)*\w+)\.', string):
         # Try to import module part in dotted name.
         # (e.g., 'threading' in 'threading.Thread').
         string = 'import %s\n' % element + string
@@ -266,7 +266,8 @@ def _execute_array_values(evaluator, array):
 
 @evaluator_method_cache()
 def infer_param(execution_context, param):
-    from jedi.evaluate.context.instance import AnonymousInstanceFunctionExecution
+    from jedi.evaluate.context.instance import InstanceArguments
+    from jedi.evaluate.context import FunctionExecutionContext
 
     def eval_docstring(docstring):
         return ContextSet.from_iterable(
@@ -280,9 +281,10 @@ def infer_param(execution_context, param):
         return NO_CONTEXTS
 
     types = eval_docstring(execution_context.py__doc__())
-    if isinstance(execution_context, AnonymousInstanceFunctionExecution) and \
-            execution_context.function_context.name.string_name == '__init__':
-        class_context = execution_context.instance.class_context
+    if isinstance(execution_context, FunctionExecutionContext) \
+            and isinstance(execution_context.var_args, InstanceArguments) \
+            and execution_context.function_context.py__name__() == '__init__':
+        class_context = execution_context.var_args.instance.class_context
         types |= eval_docstring(class_context.py__doc__())
 
     return types

--- a/dependencies/jedi/evaluate/dynamic.py
+++ b/dependencies/jedi/evaluate/dynamic.py
@@ -28,22 +28,30 @@ from jedi.evaluate.helpers import is_stdlib_path
 from jedi.evaluate.utils import to_list
 from jedi.parser_utils import get_parent_scope
 from jedi.evaluate.context import ModuleContext, instance
-from jedi.evaluate.base_context import ContextSet
-
+from jedi.evaluate.base_context import ContextSet, NO_CONTEXTS
+from jedi.evaluate import recursion
 
 
 MAX_PARAM_SEARCHES = 20
 
 
-class MergedExecutedParams(object):
+class DynamicExecutedParams(object):
     """
     Simulates being a parameter while actually just being multiple params.
     """
-    def __init__(self, executed_params):
+
+    def __init__(self, evaluator, executed_params):
+        self.evaluator = evaluator
         self._executed_params = executed_params
 
     def infer(self):
-        return ContextSet.from_sets(p.infer() for p in self._executed_params)
+        with recursion.execution_allowed(self.evaluator, self) as allowed:
+            # We need to catch recursions that may occur, because an
+            # anonymous functions can create an anonymous parameter that is
+            # more or less self referencing.
+            if allowed:
+                return ContextSet.from_sets(p.infer() for p in self._executed_params)
+            return NO_CONTEXTS
 
 
 @debug.increase_indent
@@ -91,10 +99,10 @@ def search_params(evaluator, execution_context, funcdef):
             )
             if function_executions:
                 zipped_params = zip(*list(
-                    function_execution.get_params()
+                    function_execution.get_executed_params()
                     for function_execution in function_executions
                 ))
-                params = [MergedExecutedParams(executed_params) for executed_params in zipped_params]
+                params = [DynamicExecutedParams(evaluator, executed_params) for executed_params in zipped_params]
                 # Evaluate the ExecutedParams to types.
             else:
                 return create_default_params(execution_context, funcdef)
@@ -200,7 +208,7 @@ def _check_name_for_execution(evaluator, context, compare_node, name, trailer):
             # Here we're trying to find decorators by checking the first
             # parameter. It's not very generic though. Should find a better
             # solution that also applies to nested decorators.
-            params = value.parent_context.get_params()
+            params = value.parent_context.get_executed_params()
             if len(params) != 1:
                 continue
             values = params[0].infer()

--- a/dependencies/jedi/evaluate/helpers.py
+++ b/dependencies/jedi/evaluate/helpers.py
@@ -19,7 +19,7 @@ def is_stdlib_path(path):
         return False
 
     base_path = os.path.join(sys.prefix, 'lib', 'python')
-    return bool(re.match(re.escape(base_path) + '\d.\d', path))
+    return bool(re.match(re.escape(base_path) + r'\d.\d', path))
 
 
 def deep_ast_copy(obj):
@@ -64,6 +64,10 @@ def evaluate_call_of_leaf(context, leaf, cut_own_trailer=False):
     The option ``cut_own_trailer`` must be set to true for the second purpose.
     """
     trailer = leaf.parent
+    if trailer.type == 'fstring':
+        from jedi.evaluate import compiled
+        return compiled.get_string_context_set(context.evaluator)
+
     # The leaf may not be the last or first child, because there exist three
     # different trailers: `( x )`, `[ x ]` and `.x`. In the first two examples
     # we should not match anything more than x.

--- a/dependencies/jedi/evaluate/imports.py
+++ b/dependencies/jedi/evaluate/imports.py
@@ -26,7 +26,7 @@ from jedi.evaluate import sys_path
 from jedi.evaluate import helpers
 from jedi.evaluate import compiled
 from jedi.evaluate import analysis
-from jedi.evaluate.utils import unite, dotted_from_fs_path
+from jedi.evaluate.utils import unite
 from jedi.evaluate.cache import evaluator_method_cache
 from jedi.evaluate.filters import AbstractNameDefinition
 from jedi.evaluate.base_context import ContextSet, NO_CONTEXTS
@@ -264,8 +264,11 @@ class Importer(object):
         )
 
     def sys_path_with_modifications(self):
-        sys_path_mod = self._evaluator.get_sys_path() \
-                       + sys_path.check_sys_path_modifications(self.module_context)
+
+        sys_path_mod = (
+            self._evaluator.get_sys_path()
+            + sys_path.check_sys_path_modifications(self.module_context)
+        )
 
         if self.import_path and self.file_path is not None \
                 and self._evaluator.environment.version_info.major == 2:
@@ -275,8 +278,9 @@ class Importer(object):
         return sys_path_mod
 
     def follow(self):
-        if not self.import_path:
+        if not self.import_path or not self._evaluator.infer_enabled:
             return NO_CONTEXTS
+
         return self._do_import(self.import_path, self.sys_path_with_modifications())
 
     def _do_import(self, import_path, sys_path):
@@ -299,6 +303,14 @@ class Importer(object):
             else:
                 # Old style
                 return self._do_import(('flaskext',) + import_path[2:], sys_path)
+
+        if import_parts[0] in settings.auto_import_modules:
+            module = _load_module(
+                self._evaluator,
+                import_names=import_parts,
+                sys_path=sys_path,
+            )
+            return ContextSet(module)
 
         module_name = '.'.join(import_parts)
         try:
@@ -341,7 +353,8 @@ class Importer(object):
                     code, module_path, is_pkg = self._evaluator.compiled_subprocess.get_module_info(
                         string=import_parts[-1],
                         path=path,
-                        full_name=module_name
+                        full_name=module_name,
+                        is_global_search=False,
                     )
                     if module_path is not None:
                         break
@@ -349,13 +362,14 @@ class Importer(object):
                     _add_error(self.module_context, import_path[-1])
                     return NO_CONTEXTS
         else:
-            debug.dbg('search_module %s in %s', import_parts[-1], self.file_path)
+            debug.dbg('global search_module %s in %s', import_parts[-1], self.file_path)
             # Override the sys.path. It works only good that way.
             # Injecting the path directly into `find_module` did not work.
             code, module_path, is_pkg = self._evaluator.compiled_subprocess.get_module_info(
                 string=import_parts[-1],
                 full_name=module_name,
                 sys_path=sys_path,
+                is_global_search=True,
             )
             if module_path is None:
                 # The module is not a package.
@@ -364,7 +378,7 @@ class Importer(object):
 
         module = _load_module(
             self._evaluator, module_path, code, sys_path,
-            module_name=module_name,
+            import_names=import_parts,
             safe_module_name=True,
         )
 
@@ -464,9 +478,13 @@ class Importer(object):
 
 
 def _load_module(evaluator, path=None, code=None, sys_path=None,
-                 module_name=None, safe_module_name=False):
+                 import_names=None, safe_module_name=False):
+    if import_names is None:
+        dotted_name = None
+    else:
+        dotted_name = '.'.join(import_names)
     try:
-        return evaluator.module_cache.get(module_name)
+        return evaluator.module_cache.get(dotted_name)
     except KeyError:
         pass
     try:
@@ -485,12 +503,10 @@ def _load_module(evaluator, path=None, code=None, sys_path=None,
         if sys_path is None:
             sys_path = evaluator.get_sys_path()
 
-        dotted_path = path and dotted_from_fs_path(path, sys_path)
-        if path is not None and path.endswith(('.py', '.zip', '.egg')) \
-                and dotted_path not in settings.auto_import_modules:
-
+        if path is not None and path.endswith(('.py', '.zip', '.egg')):
             module_node = evaluator.parse(
-                code=code, path=path, cache=True, diff_cache=True,
+                code=code, path=path, cache=True,
+                diff_cache=settings.fast_parser,
                 cache_path=settings.cache_directory)
 
             from jedi.evaluate.context import ModuleContext
@@ -500,10 +516,11 @@ def _load_module(evaluator, path=None, code=None, sys_path=None,
                 code_lines=get_cached_code_lines(evaluator.grammar, path),
             )
         else:
-            module = compiled.load_module(evaluator, path=path, sys_path=sys_path)
+            assert dotted_name is not None
+            module = compiled.load_module(evaluator, dotted_name=dotted_name, sys_path=sys_path)
 
-    if module is not None and module_name is not None:
-        add_module_to_cache(evaluator, module_name, module, safe=safe_module_name)
+    if module is not None and dotted_name is not None:
+        add_module_to_cache(evaluator, dotted_name, module, safe=safe_module_name)
 
     return module
 
@@ -542,10 +559,11 @@ def get_modules_containing_name(evaluator, modules, name):
             code = python_bytes_to_unicode(f.read(), errors='replace')
             if name in code:
                 e_sys_path = evaluator.get_sys_path()
-                module_name = sys_path.dotted_path_in_sys_path(e_sys_path, path)
+                import_names = sys_path.dotted_path_in_sys_path(e_sys_path, path)
                 module = _load_module(
                     evaluator, path, code,
-                    sys_path=e_sys_path, module_name=module_name
+                    sys_path=e_sys_path,
+                    import_names=import_names,
                 )
                 return module
 

--- a/dependencies/jedi/evaluate/lazy_context.py
+++ b/dependencies/jedi/evaluate/lazy_context.py
@@ -1,6 +1,7 @@
 from jedi.evaluate.base_context import ContextSet, NO_CONTEXTS
 from jedi.common.utils import monkeypatch
 
+
 class AbstractLazyContext(object):
     def __init__(self, data):
         self.data = data

--- a/dependencies/jedi/evaluate/param.py
+++ b/dependencies/jedi/evaluate/param.py
@@ -41,7 +41,7 @@ class ExecutedParam(object):
         return '<%s: %s>' % (self.__class__.__name__, self.string_name)
 
 
-def get_params(execution_context, var_args):
+def get_executed_params(execution_context, var_args):
     result_params = []
     param_dict = {}
     funcdef = execution_context.tree_node

--- a/dependencies/jedi/evaluate/pep0484.py
+++ b/dependencies/jedi/evaluate/pep0484.py
@@ -157,8 +157,8 @@ def infer_param(execution_context, param):
                 "Comments length != Params length %s %s",
                 params_comments, all_params
             )
-        from jedi.evaluate.context.instance import BaseInstanceFunctionExecution
-        if isinstance(execution_context, BaseInstanceFunctionExecution):
+        from jedi.evaluate.context.instance import InstanceArguments
+        if isinstance(execution_context.var_args, InstanceArguments):
             if index == 0:
                 # Assume it's self, which is already handled
                 return NO_CONTEXTS

--- a/dependencies/jedi/evaluate/recursion.py
+++ b/dependencies/jedi/evaluate/recursion.py
@@ -65,7 +65,7 @@ def execution_allowed(evaluator, node):
 
     if node in pushed_nodes:
         debug.warning('catched stmt recursion: %s @%s', node,
-                      node.start_pos)
+                      getattr(node, 'start_pos', None))
         yield False
     else:
         try:
@@ -77,14 +77,14 @@ def execution_allowed(evaluator, node):
 
 def execution_recursion_decorator(default=NO_CONTEXTS):
     def decorator(func):
-        def wrapper(execution, **kwargs):
-            detector = execution.evaluator.execution_recursion_detector
-            allowed = detector.push_execution(execution)
+        def wrapper(self, **kwargs):
+            detector = self.evaluator.execution_recursion_detector
+            allowed = detector.push_execution(self)
             try:
                 if allowed:
                     result = default
                 else:
-                    result = func(execution, **kwargs)
+                    result = func(self, **kwargs)
             finally:
                 detector.pop_execution()
             return result

--- a/dependencies/jedi/evaluate/stdlib.py
+++ b/dependencies/jedi/evaluate/stdlib.py
@@ -9,21 +9,18 @@ Note that this module exists only to implement very specific functionality in
 the standard library. The usual way to understand the standard library is the
 compiled module that returns the types for C-builtins.
 """
-import re
-
 import parso
 
 from jedi._compatibility import force_unicode
 from jedi import debug
-from jedi.evaluate.arguments import ValuesArguments
+from jedi.evaluate.arguments import ValuesArguments, repack_with_argument_clinic
 from jedi.evaluate import analysis
 from jedi.evaluate import compiled
-from jedi.evaluate.context.instance import InstanceFunctionExecution, \
-    AbstractInstanceContext, CompiledInstance, BoundMethod, \
-    AnonymousInstanceFunctionExecution
+from jedi.evaluate.context.instance import \
+    AbstractInstanceContext, CompiledInstance, BoundMethod, InstanceArguments
 from jedi.evaluate.base_context import ContextualizedNode, \
     NO_CONTEXTS, ContextSet
-from jedi.evaluate.context import ClassContext, ModuleContext
+from jedi.evaluate.context import ClassContext, ModuleContext, FunctionExecutionContext
 from jedi.evaluate.context import iterable
 from jedi.evaluate.lazy_context import LazyTreeContext
 from jedi.evaluate.syntax_tree import is_string
@@ -72,7 +69,7 @@ def execute(evaluator, obj, arguments):
         except KeyError:
             pass
         else:
-            return func(evaluator, obj, arguments)
+            return func(evaluator, obj, arguments=arguments)
     raise NotInStdLib()
 
 
@@ -89,42 +86,22 @@ def argument_clinic(string, want_obj=False, want_context=False, want_arguments=F
     """
     Works like Argument Clinic (PEP 436), to validate function params.
     """
-    clinic_args = []
-    allow_kwargs = False
-    optional = False
-    while string:
-        # Optional arguments have to begin with a bracket. And should always be
-        # at the end of the arguments. This is therefore not a proper argument
-        # clinic implementation. `range()` for exmple allows an optional start
-        # value at the beginning.
-        match = re.match('(?:(?:(\[),? ?|, ?|)(\w+)|, ?/)\]*', string)
-        string = string[len(match.group(0)):]
-        if not match.group(2):  # A slash -> allow named arguments
-            allow_kwargs = True
-            continue
-        optional = optional or bool(match.group(1))
-        word = match.group(2)
-        clinic_args.append((word, optional, allow_kwargs))
 
     def f(func):
-        def wrapper(evaluator, obj, arguments):
+        @repack_with_argument_clinic(string, keep_arguments_param=True)
+        def wrapper(evaluator, obj, *args, **kwargs):
+            arguments = kwargs.pop('arguments')
+            assert not kwargs  # Python 2...
             debug.dbg('builtin start %s' % obj, color='MAGENTA')
             result = NO_CONTEXTS
-            try:
-                lst = list(arguments.eval_argument_clinic(clinic_args))
-            except ValueError:
-                pass
-            else:
-                kwargs = {}
-                if want_context:
-                    kwargs['context'] = arguments.context
-                if want_obj:
-                    kwargs['obj'] = obj
-                if want_arguments:
-                    kwargs['arguments'] = arguments
-                result = func(evaluator, *lst, **kwargs)
-            finally:
-                debug.dbg('builtin end: %s', result, color='MAGENTA')
+            if want_context:
+                kwargs['context'] = arguments.context
+            if want_obj:
+                kwargs['obj'] = obj
+            if want_arguments:
+                kwargs['arguments'] = arguments
+            result = func(evaluator, *args, **kwargs)
+            debug.dbg('builtin end: %s', result, color='MAGENTA')
             return result
 
         return wrapper
@@ -187,10 +164,11 @@ class SuperInstance(AbstractInstanceContext):
 @argument_clinic('[type[, obj]], /', want_context=True)
 def builtins_super(evaluator, types, objects, context):
     # TODO make this able to detect multiple inheritance super
-    if isinstance(context, (InstanceFunctionExecution,
-                            AnonymousInstanceFunctionExecution)):
-        su = context.instance.py__class__().py__bases__()
-        return su[0].infer().execute_evaluated()
+    if isinstance(context, FunctionExecutionContext):
+        if isinstance(context.var_args, InstanceArguments):
+            su = context.var_args.instance.py__class__().py__bases__()
+            return su[0].infer().execute_evaluated()
+
     return NO_CONTEXTS
 
 
@@ -334,8 +312,8 @@ _implemented = {
         'deepcopy': _return_first_param,
     },
     'json': {
-        'load': lambda *args: NO_CONTEXTS,
-        'loads': lambda *args: NO_CONTEXTS,
+        'load': lambda evaluator, obj, arguments: NO_CONTEXTS,
+        'loads': lambda evaluator, obj, arguments: NO_CONTEXTS,
     },
     'collections': {
         'namedtuple': collections_namedtuple,

--- a/dependencies/jedi/evaluate/sys_path.py
+++ b/dependencies/jedi/evaluate/sys_path.py
@@ -198,7 +198,7 @@ def _get_buildout_script_paths(search_path):
 
 def dotted_path_in_sys_path(sys_path, module_path):
     """
-    Returns the dotted path inside a sys.path.
+    Returns the dotted path inside a sys.path as a list of names.
     """
     # First remove the suffix.
     for suffix in all_suffixes():
@@ -221,6 +221,6 @@ def dotted_path_in_sys_path(sys_path, module_path):
                 for string in split:
                     if not string or '.' in string:
                         return None
-                return '.'.join(split)
+                return split
 
     return None

--- a/dependencies/jedi/evaluate/utils.py
+++ b/dependencies/jedi/evaluate/utils.py
@@ -11,7 +11,7 @@ from jedi._compatibility import reraise
 _sep = os.path.sep
 if os.path.altsep is not None:
     _sep += os.path.altsep
-_path_re = re.compile('(?:\.[^{0}]+|[{0}]__init__\.py)$'.format(re.escape(_sep)))
+_path_re = re.compile(r'(?:\.[^{0}]+|[{0}]__init__\.py)$'.format(re.escape(_sep)))
 del _sep
 
 
@@ -117,38 +117,3 @@ def indent_block(text, indention='    '):
         text = text[:-1]
     lines = text.split('\n')
     return '\n'.join(map(lambda s: indention + s, lines)) + temp
-
-
-def dotted_from_fs_path(fs_path, sys_path):
-    """
-    Changes `/usr/lib/python3.4/email/utils.py` to `email.utils`.  I.e.
-    compares the path with sys.path and then returns the dotted_path. If the
-    path is not in the sys.path, just returns None.
-    """
-    if os.path.basename(fs_path).startswith('__init__.'):
-        # We are calculating the path. __init__ files are not interesting.
-        fs_path = os.path.dirname(fs_path)
-
-    # prefer
-    #   - UNIX
-    #     /path/to/pythonX.Y/lib-dynload
-    #     /path/to/pythonX.Y/site-packages
-    #   - Windows
-    #     C:\path\to\DLLs
-    #     C:\path\to\Lib\site-packages
-    # over
-    #   - UNIX
-    #     /path/to/pythonX.Y
-    #   - Windows
-    #     C:\path\to\Lib
-    path = ''
-    for s in sys_path:
-        if (fs_path.startswith(s) and len(path) < len(s)):
-            path = s
-
-    # - Window
-    # X:\path\to\lib-dynload/datetime.pyd => datetime
-    module_path = fs_path[len(path):].lstrip(os.path.sep).lstrip('/')
-    # - Window
-    # Replace like X:\path\to\something/foo/bar.py
-    return _path_re.sub('', module_path).replace(os.path.sep, '.').replace('/', '.')

--- a/dependencies/jedi/parser_utils.py
+++ b/dependencies/jedi/parser_utils.py
@@ -1,3 +1,4 @@
+import re
 import textwrap
 from inspect import cleandoc
 
@@ -158,6 +159,7 @@ def get_call_signature(funcdef, width=72, call_string=None):
         p = '(' + ''.join(param.get_code() for param in funcdef.get_params()).strip() + ')'
     else:
         p = funcdef.children[2].get_code()
+    p = re.sub(r'\s+', ' ', p)
     if funcdef.annotation:
         rtype = " ->" + funcdef.annotation.get_code()
     else:
@@ -183,6 +185,8 @@ def get_doc_with_call_signature(scope_node):
     doc = clean_scope_docstring(scope_node)
     if call_signature is None:
         return doc
+    if not doc:
+        return call_signature
     return '%s\n\n%s' % (call_signature, doc)
 
 

--- a/dependencies/jedi/settings.py
+++ b/dependencies/jedi/settings.py
@@ -144,7 +144,8 @@ Check for `isinstance` and other information to infer a type.
 """
 
 auto_import_modules = [
-    'hashlib',  # setattr
+    'hashlib',  # hashlib is mostly using setattr, which jedi doesn't understand
+    'gi',  # This third-party repository (GTK stuff) doesn't really work with jedi
 ]
 """
 Modules that are not analyzed but imported, although they contain Python code.

--- a/dependencies/jedi/utils.py
+++ b/dependencies/jedi/utils.py
@@ -113,7 +113,7 @@ def setup_readline(namespace_module=__main__):
         # this code. This didn't use to be an issue until 3.3. Starting with
         # 3.4 this is different, it always overwrites the completer if it's not
         # already imported here.
-        import rlcompleter
+        import rlcompleter  # noqa: F401
         import readline
     except ImportError:
         print("Jedi: Module readline not available.")
@@ -138,5 +138,5 @@ def version_info():
     """
     Version = namedtuple('Version', 'major, minor, micro')
     from jedi import __version__
-    tupl = re.findall('[a-z]+|\d+', __version__)
+    tupl = re.findall(r'[a-z]+|\d+', __version__)
     return Version(*[x if i == 3 else int(x) for i, x in enumerate(tupl)])

--- a/jedi_0.13.x.patch
+++ b/jedi_0.13.x.patch
@@ -1,0 +1,38 @@
+diff --git dependencies/jedi/_compatibility.py dependencies/jedi/_compatibility.py
+index 9b5edc8..81b844a 100644
+--- dependencies/jedi/_compatibility.py
++++ dependencies/jedi/_compatibility.py
+@@ -150,6 +150,7 @@ def find_module_pre_py34(string, path=None, full_name=None, is_global_search=Tru
+ 
+ 
+ find_module = find_module_py34 if is_py3 else find_module_pre_py34
++find_module = find_module_py33 if py_version == 33 else find_module
+ find_module.__doc__ = """
+ Provides information about a module.
+ 
+diff --git dependencies/jedi/evaluate/compiled/access.py dependencies/jedi/evaluate/compiled/access.py
+index ab1d354..7fd5811 100644
+--- dependencies/jedi/evaluate/compiled/access.py
++++ dependencies/jedi/evaluate/compiled/access.py
+@@ -5,7 +5,7 @@ from textwrap import dedent
+ import operator as op
+ from collections import namedtuple
+ 
+-from jedi._compatibility import unicode, is_py3, builtins, \
++from jedi._compatibility import unicode, is_py3, py_version, builtins, \
+     py_version, force_unicode, print_to_stderr
+ from jedi.evaluate.compiled.getattr_static import getattr_static
+ 
+@@ -32,9 +32,11 @@ if is_py3:
+     NOT_CLASS_TYPES += (
+         types.MappingProxyType,
+         types.SimpleNamespace,
+-        types.DynamicClassAttribute,
+     )
+ 
++    if not py_version == 33:
++        NOT_CLASS_TYPES += (types.DynamicClassAttribute,)
++
+ 
+ # Those types don't exist in typing.
+ MethodDescriptorType = type(str.replace)

--- a/sublime_jedi/daemon.py
+++ b/sublime_jedi/daemon.py
@@ -145,10 +145,8 @@ class Daemon:
             self.env = environment.create_environment(python_virtualenv,
                                                       safe=False)
         elif python_interpreter:
-            self.env = environment.Environment(
-                environment._get_python_prefix(python_interpreter),
-                python_interpreter
-            )
+            self.env = environment.create_environment(python_interpreter,
+                                                      safe=False)
         else:
             self.env = jedi.get_default_environment()
 


### PR DESCRIPTION
Change to update Jedi package to v0.13.1.

**Note:** this does cause an issue, where Jedi has now dropped support for [Python 3.3](https://github.com/davidhalter/jedi/pull/1019) - so had to patch `access.py` [here](https://github.com/magnetikonline/SublimeJEDI/blob/8584dad2c16f60940a4fcd393f79579bddbd17cc/dependencies/jedi/evaluate/compiled/access.py#L8-L9) and [here](https://github.com/magnetikonline/SublimeJEDI/blob/8584dad2c16f60940a4fcd393f79579bddbd17cc/dependencies/jedi/evaluate/compiled/access.py#L37-L39).

- Can only assume that SublimeText 3 comes packaged with an earlier point release of Python 3?
- Technically this does also mean the `Makefile` won't work as is without patching of the `jedi` package.

Otherwise, all good. 