### PR TITLE
Adds `only_complete_after_regex` setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,21 @@ set (additionally to the trigger above):
     }
 
 
+#### Autocomplete after only certain characters
+
+If you want Jedi auto-completion only after certain characters, you can use the `only_complete_after_regex` setting.
+
+For example, if you want Jedi auto-completion only after the `.` character but don't want to affect auto-completion from other packages, insert the following into `User/sublime_jedi.sublime-settings`:
+
+~~~json
+{
+  "only_complete_after_regex": "\\.",
+}
+~~~
+
+Using this setting in this way means you can remove `"auto_complete_selector": "-",` from `User/Python.sublime-settings`, so that the rest of your packages still trigger auto-completion after every keystroke.
+
+
 #### Goto / Go Definition
 
 Find function / variable / class definition

--- a/sublime_jedi.sublime-settings
+++ b/sublime_jedi.sublime-settings
@@ -46,5 +46,8 @@
     "enable_tooltip": true,
 
     // SublimeREPL integration
-    "enable_in_sublime_repl": false
+    "enable_in_sublime_repl": false,
+
+    // Only show completions after character that matches this regex
+    "only_complete_after_regex": ""
 }

--- a/sublime_jedi/completion.py
+++ b/sublime_jedi/completion.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import re
+
 import sublime
 import sublime_plugin
 
@@ -148,12 +150,18 @@ class Autocomplete(sublime_plugin.ViewEventListener):
             settings['sublime_completions_visibility'] in ('default', 'jedi')
         )
 
+        previous_char = self.view.substr(locations[0] - 1)
+        if settings['only_complete_after_regex']:
+            if not re.match(settings['only_complete_after_regex'], previous_char):
+                return False
+
         cplns = ask_daemon_with_timeout(
             self.view,
             'autocomplete',
             location=locations[0],
             timeout=settings['completion_timeout']
         )
+
         logger.info("Completion completed.")
 
         cplns = [tuple(x) for x in self._sort_completions(cplns)]

--- a/sublime_jedi/utils.py
+++ b/sublime_jedi/utils.py
@@ -38,6 +38,9 @@ def get_settings(view):
     sublime_completions_visibility = get_settings_param(
         view, 'sublime_completions_visibility', 'default')
 
+    only_complete_after_regex = get_settings_param(
+        view, 'only_complete_after_regex', '')
+
     first_folder = ''
     if view.window().folders():
         first_folder = os.path.split(view.window().folders()[0])[-1]
@@ -53,6 +56,7 @@ def get_settings(view):
         'sublime_completions_visibility': sublime_completions_visibility,
         'follow_imports': get_settings_param(view, 'follow_imports', True),
         'completion_timeout': get_settings_param(view, 'comletion_timeout', 3),
+        'only_complete_after_regex': only_complete_after_regex,
     }
 
 


### PR DESCRIPTION
 Adds a setting, `only_complete_after_regex`, that makes it easier to get around slowdown issues with JEDI.

This allows the user to only trigger auto-completions **immediately after** a character that matches a pattern they specify.

For example, they can enter `"only_complete_after_regex": "\\."` into `sublime_jedi.sublime-settings` to only enable auto-completion after the `.` char.

I didn't add info about this setting to the README because I'm not sure where it should go or how it should be formatted.