### PR TITLE
Rename all occurrences of symbol, and automatically highlight all occurrences of symbol

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,0 +1,21 @@
+[
+  {
+    "caption": "SublimeJedi: GoTo Definition",
+    "command": "sublime_jedi_goto"
+  },
+
+  {
+    "caption": "SublimeJedi: Find/Rename Usages",
+    "command": "sublime_jedi_find_usages"
+  },
+
+  {
+    "caption": "SublimeJedi: Show Docstring",
+    "command": "sublime_jedi_docstring"
+  },
+
+  {
+    "caption": "SublimeJedi: Show Signature",
+    "command": "sublime_jedi_signature"
+  }
+]

--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ Find function / method / variable / class usage, definition.
 
 Shortcut: `ALT+SHIFT+F`.
 
+There are two settings related to finding usages:
+
+- `highlight_usages_on_select`: highlights usages of symbol in file when symbol is selected (default `false`)
+- `highlight_usages_color`: color for highlighted symbols (default `"region.bluish"`)
+
 
 #### Show Python Docstring
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ There are two settings related to finding usages:
 
 - `highlight_usages_on_select`: highlights usages of symbol in file when symbol is selected (default `false`)
 - `highlight_usages_color`: color for highlighted symbols (default `"region.bluish"`)
+    + other available options are `"region.redish", "region.orangish", "region.yellowish", "region.greenish", "region.bluish", "region.purplish", "region.pinkish", "region.blackish"`
+    + these colors are actually scopes that were added to Sublime Text around build 3148; these scopes aren't documented, but the __BracketHighlighter__ plugin has an excellent explanation [here](http://facelessuser.github.io/BracketHighlighter/customize/#configuring-highlight-style)
 
 
 #### Show Python Docstring

--- a/README.md
+++ b/README.md
@@ -100,6 +100,21 @@ set (additionally to the trigger above):
     }
 
 
+#### Autocomplete after only certain characters
+
+If you want Jedi auto-completion only after certain characters, you can use the `only_complete_after_regex` setting.
+
+For example, if you want Jedi auto-completion only after the `.` character but don't want to affect auto-completion from other packages, insert the following into `User/sublime_jedi.sublime-settings`:
+
+~~~json
+{
+  "only_complete_after_regex": "\\.",
+}
+~~~
+
+Using this setting in this way means you can remove `"auto_complete_selector": "-",` from `User/Python.sublime-settings`, so that the rest of your packages still trigger auto-completion after every keystroke.
+
+
 #### Goto / Go Definition
 
 Find function / variable / class definition

--- a/sublime_jedi.sublime-settings
+++ b/sublime_jedi.sublime-settings
@@ -46,5 +46,8 @@
     "enable_tooltip": true,
 
     // SublimeREPL integration
-    "enable_in_sublime_repl": false
+    "enable_in_sublime_repl": false,
+
+    // Only show completions after character that matches this regex
+    "only_complete_after_regex": ""
 }

--- a/sublime_jedi.sublime-settings
+++ b/sublime_jedi.sublime-settings
@@ -51,6 +51,11 @@
     // Only show completions after character that matches this regex
     "only_complete_after_regex": "",
 
-    // Highlight variable usages in current view on hover
-    "highlight_usages_on_hover": false
+    // Highlight symbol usages in current view on select
+    "highlight_usages_on_select": false,
+
+    // Highlight color for symbol usages: an empty string for the default color, or one of
+    // "region.redish", "region.orangish", "region.yellowish", "region.greenish",
+    // "region.bluish", "region.purplish", "region.pinkish", "region.blackish"
+    "highlight_usages_color": "region.bluish"
 }

--- a/sublime_jedi.sublime-settings
+++ b/sublime_jedi.sublime-settings
@@ -49,5 +49,8 @@
     "enable_in_sublime_repl": false,
 
     // Only show completions after character that matches this regex
-    "only_complete_after_regex": ""
+    "only_complete_after_regex": "",
+
+    // Highlight variable usages in current view on hover
+    "highlight_usages_on_hover": false
 }

--- a/sublime_jedi/__init__.py
+++ b/sublime_jedi/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from .completion import SublimeJediParamsAutocomplete, Autocomplete
-from .go_to import SublimeJediFindUsages, SublimeJediGoto
+from .go_to import SublimeJediFindUsages, SublimeJediEventListener, SublimeJediGoto
 from .helper import (
     SublimeJediDocstring, SublimeJediSignature, SublimeJediTooltip,
     HelpMessageCommand
@@ -9,6 +9,7 @@ from .helper import (
 __all__ = [
     'SublimeJediGoto',
     'SublimeJediFindUsages',
+    'SublimeJediEventListener',
     'SublimeJediParamsAutocomplete',
     'Autocomplete',
     'SublimeJediDocstring',

--- a/sublime_jedi/completion.py
+++ b/sublime_jedi/completion.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import re
+
 import sublime
 import sublime_plugin
 
@@ -148,12 +150,18 @@ class Autocomplete(sublime_plugin.ViewEventListener):
             settings['sublime_completions_visibility'] in ('default', 'jedi')
         )
 
+        previous_char = self.view.substr(locations[0] - 1)
+        if settings['only_complete_after_regex']:
+            if not re.match(settings['only_complete_after_regex'], previous_char):
+                return False
+
         cplns = ask_daemon_with_timeout(
             self.view,
             'autocomplete',
             location=locations[0],
             timeout=settings['completion_timeout']
         )
+
         logger.info("Completion completed.")
 
         cplns = [tuple(x) for x in self._sort_completions(cplns)]

--- a/sublime_jedi/go_to.py
+++ b/sublime_jedi/go_to.py
@@ -265,15 +265,14 @@ def expand_selection(view, point):
 class SublimeJediEventListener(sublime_plugin.EventListener):
 
     def on_selection_modified_async(self, view) -> None:
-        if not is_python_scope(view, view.sel()[0].begin()):
+        should_highlight = get_settings_param(view, 'highlight_usages_on_hover')
+        if not is_python_scope(view, view.sel()[0].begin()) or not view.file_name() or not should_highlight:
             return
         highlight_usages(view)
 
 
 @debounce(0.35)
 def highlight_usages(view) -> None:
-    if not view.file_name():
-        return
     ask_daemon(view, handle_highlight_usages, 'usages')
 
 

--- a/sublime_jedi/go_to.py
+++ b/sublime_jedi/go_to.py
@@ -266,7 +266,7 @@ def text_point(text: str, row: int, col: int) -> int:
 class SublimeJediEventListener(sublime_plugin.EventListener):
 
     def on_selection_modified_async(self, view) -> None:
-        should_highlight = get_settings_param(view, 'highlight_usages_on_hover')
+        should_highlight = get_settings_param(view, 'highlight_usages_on_select')
         if not is_python_scope(view, view.sel()[0].begin()) or not view.file_name() or not should_highlight:
             return
         highlight_usages(view)
@@ -294,5 +294,7 @@ def handle_highlight_usages(view, options):
         view.erase_regions('sublime-jedi-usages')
         return
 
-    view.add_regions("sublime-jedi-usages", regions, "constant.numeric",
+    highlight_color = get_settings_param(view, 'highlight_usages_color')
+
+    view.add_regions("sublime-jedi-usages", regions, highlight_color or "region.bluish",
                      flags=sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE | sublime.DRAW_SOLID_UNDERLINE)

--- a/sublime_jedi/go_to.py
+++ b/sublime_jedi/go_to.py
@@ -237,7 +237,14 @@ class SublimeJediFindUsages(BaseLookUpJediCommand, sublime_plugin.TextCommand):
             partial(self._jump_to_in_window, transient=True)(idx - 1 if idx != -1 else idx)
 
         # Show the user a selection of filenames
-        first_option = [["rename " + '"{}"'.format(var), "{} occurrences".format(len(options))]]
+        files = set()  # type: Set[str]
+        for option in options:
+            files.add(option[0])
+        first_option = [[
+            "rename " + '"{}"'.format(var),
+            "{} occurrence{} in {} file{}".format(
+                len(options), 's' if len(options) != 1 else '', len(files), 's' if len(files) != 1 else '')
+        ]]
         active_window.show_quick_panel(
             first_option + [self.prepare_option(o) for o in options],
             handle_choose,

--- a/sublime_jedi/utils.py
+++ b/sublime_jedi/utils.py
@@ -38,6 +38,9 @@ def get_settings(view):
     sublime_completions_visibility = get_settings_param(
         view, 'sublime_completions_visibility', 'default')
 
+    only_complete_after_regex = get_settings_param(
+        view, 'only_complete_after_regex', '')
+
     first_folder = ''
     if view.window().folders():
         first_folder = os.path.split(view.window().folders()[0])[-1]
@@ -53,6 +56,7 @@ def get_settings(view):
         'sublime_completions_visibility': sublime_completions_visibility,
         'follow_imports': get_settings_param(view, 'follow_imports', True),
         'completion_timeout': get_settings_param(view, 'comletion_timeout', 3),
+        'only_complete_after_regex': only_complete_after_regex,
     }
 
 

--- a/sublime_jedi/utils.py
+++ b/sublime_jedi/utils.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import os
 import json
 import re
+from threading import Timer
 
 import sublime
 
@@ -214,3 +215,18 @@ def unique(items, pred=lambda x: x):
             continue
         stack.add(calculated)
         yield i
+
+
+def debounce(wait):
+    def decorator(fn):
+        def debounced(*args, **kwargs):
+            def call():
+                fn(*args, **kwargs)
+            try:
+                debounced.t.cancel()
+            except AttributeError:
+                pass
+            debounced.t = Timer(wait, call)
+            debounced.t.start()
+        return debounced
+    return decorator


### PR DESCRIPTION
This PR adds two new functionalities.

The first is the ability to rename all occurrences of a symbol in a project.

It piggybacks on the `sublime_jedi_find_usages` command by adding a first option that allows users to rename the symbol in all files in the project.

<img width="1251" alt="Screen Shot 2019-07-13 at 2 46 04 PM" src="https://user-images.githubusercontent.com/1524088/61175908-0848e200-a57d-11e9-91a7-094e9d68f2ea.png">

If the user chooses this first option, they are prompted to change the name of the symbol using `Window.show_input_panel`.

<img width="577" alt="Screen Shot 2019-07-13 at 2 46 31 PM" src="https://user-images.githubusercontent.com/1524088/61175910-10088680-a57d-11e9-97c1-218f0e19c060.png">

Also visible the first screenshot is the new functionality to optionally highlight all occurrences of a symbol. Occurrences of `logger` are underlined whenever the selection changes (by using an `EventListener` and `View.add_regions`). Calls to `ask_daemon` to get usages are [debounced](https://davidwalsh.name/javascript-debounce-function) by 350ms.

By default, this behavior is disabled. It can be enabled with the `highlight_usages_on_select` setting. Users can change the underline color with the `highlight_usages_color` settings, which must be an empty string, or one of `("region.redish", "region.orangish", "region.yellowish", "region.greenish", "region.bluish", "region.purplish", "region.pinkish", "region.blackish")`.

-----

Finally, this PR adds the `Default.sublime-commands` file, so that the `sublime_jedi_goto`, `sublime_jedi_find_usages`, `sublime_jedi_docstring`, `sublime_jedi_signature` commands are discoverable from the command palette.