### PR TITLE
add quick python select/switch function

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,21 +1,26 @@
 [
-  {
-    "caption": "SublimeJedi: GoTo Definition",
-    "command": "sublime_jedi_goto"
-  },
+    {
+        "caption": "SublimeJedi: GoTo Definition",
+        "command": "sublime_jedi_goto"
+    },
 
-  {
-    "caption": "SublimeJedi: Find/Rename Usages",
-    "command": "sublime_jedi_find_usages"
-  },
+    {
+        "caption": "SublimeJedi: Find/Rename Usages",
+        "command": "sublime_jedi_find_usages"
+    },
 
-  {
-    "caption": "SublimeJedi: Show Docstring",
-    "command": "sublime_jedi_docstring"
-  },
+    {
+        "caption": "SublimeJedi: Show Docstring",
+        "command": "sublime_jedi_docstring"
+    },
 
-  {
-    "caption": "SublimeJedi: Show Signature",
-    "command": "sublime_jedi_signature"
-  }
+    {
+        "caption": "SublimeJedi: Show Signature",
+        "command": "sublime_jedi_signature"
+    },
+
+    {
+        "caption": "SublimeJedi: Select Python",
+        "command": "sublime_jedi_py_select"
+    }
 ]

--- a/README.md
+++ b/README.md
@@ -263,6 +263,32 @@ Enabling this option to try to bring more comfortable workflow.
 Please note, if you are using [SublimeAllAutocomplete](https://github.com/alienhard/SublimeAllAutocomplete) - you should not care about this option.
 
 
+### Quick Select/Switch Python
+
+Specify python interpreters used now and avaliabe
+
+```json
+// User/sublime_jedi.sublime-settings
+{
+    "python_interpreter": "D:/Python36/python.exe",
+    "python_interpreters":
+    [
+        "D:/Python27/python.exe",
+        "D:/Python36/python.exe",
+        "D:/Python27/venv/Scripts/python.exe",
+        "D:/Python27/vexe/Scripts/python.exe",
+        "D:/Python36/venv/Scripts/python.exe",
+        "D:/Python36/vexe/Scripts/python.exe",
+        "D:/Python36/vweb/Scripts/python.exe"
+    ]
+}
+``` 
+
+And then, you can quick select/switch python by input 'SublimeJedi: Select Python' in command palette
+
+When a python file is opened or activated, the python interpreter used by JEDI will show on statusbar
+
+
 #### Logging
 
 Plugin uses Python logging lib to log everything. It allow collect propper information in right order rather then `print()`-ing to sublime console.

--- a/sublime_jedi/__init__.py
+++ b/sublime_jedi/__init__.py
@@ -5,6 +5,7 @@ from .helper import (
     SublimeJediDocstring, SublimeJediSignature, SublimeJediTooltip,
     HelpMessageCommand
 )
+from .py_select import PySelectEventListener, SublimeJediPySelect
 
 __all__ = [
     'SublimeJediGoto',
@@ -15,5 +16,7 @@ __all__ = [
     'SublimeJediDocstring',
     'SublimeJediSignature',
     'SublimeJediTooltip',
-    'HelpMessageCommand'
+    'HelpMessageCommand',
+    'PySelectEventListener',
+    'SublimeJediPySelect'
 ]

--- a/sublime_jedi/py_select.py
+++ b/sublime_jedi/py_select.py
@@ -1,0 +1,44 @@
+import sublime, sublime_plugin
+from .utils import PythonCommandMixin, is_python_scope
+from .settings import get_plugin_settings
+
+
+class PySelectEventListener(sublime_plugin.EventListener):
+
+    def show_py(self, view) -> None:
+        '''
+        Show the Python Interpreter used by SublimeJEDI on statusbar
+        '''
+        if is_python_scope(view, view.sel()[0].begin()):
+            view.window().status_message('   Py: %s' %get_plugin_settings().get('python_interpreter'))
+
+    def on_load(self, view) -> None:
+        self.show_py(view)
+
+    def on_activated(self, view) -> None:
+        self.show_py(view)
+
+
+class ListAvaliablePython(sublime_plugin.ListInputHandler):
+    def __init__(self, view):
+        self.view = view
+
+    def list_items(self):
+        return get_plugin_settings().get('python_interpreters')
+
+    def confirm(self, sel_py):
+        get_plugin_settings().set('python_interpreter', sel_py)
+        sublime.save_settings('sublime_jedi.sublime-settings')
+
+
+class SublimeJediPySelect(PythonCommandMixin, sublime_plugin.TextCommand):
+    '''
+    Select Python Interpreter
+    '''
+
+    def run(self, edit, list_avaliable_python):
+        # list_avaliable_python: the selected python
+        pass
+
+    def input(self, args):
+        return ListAvaliablePython(self.view)

--- a/sublime_jedi/py_select.py
+++ b/sublime_jedi/py_select.py
@@ -10,7 +10,7 @@ class PySelectEventListener(sublime_plugin.EventListener):
         Show the Python Interpreter used by SublimeJEDI on statusbar
         '''
         if is_python_scope(view, view.sel()[0].begin()):
-            view.window().status_message('   Py: %s' %get_plugin_settings().get('python_interpreter'))
+            view.window().status_message('   Py: {}'.format(get_plugin_settings().get('python_interpreter')))
 
     def on_load(self, view) -> None:
         self.show_py(view)

--- a/sublime_jedi/py_select.py
+++ b/sublime_jedi/py_select.py
@@ -1,6 +1,6 @@
 import sublime, sublime_plugin
 from .utils import PythonCommandMixin, is_python_scope
-from .settings import get_plugin_settings
+from .settings import get_plugin_settings, get_settings_param
 
 
 class PySelectEventListener(sublime_plugin.EventListener):
@@ -9,8 +9,10 @@ class PySelectEventListener(sublime_plugin.EventListener):
         '''
         Show the Python Interpreter used by SublimeJEDI on statusbar
         '''
-        if is_python_scope(view, view.sel()[0].begin()):
-            view.window().status_message('   Py: {}'.format(get_plugin_settings().get('python_interpreter')))
+        cur_py = get_settings_param(view, 'python_interpreter')
+
+        if is_python_scope(view, view.sel()[0].begin()) and cur_py:
+            view.window().status_message('   Py: {}'.format(cur_py))
 
     def on_load(self, view) -> None:
         self.show_py(view)
@@ -24,11 +26,14 @@ class ListAvaliablePython(sublime_plugin.ListInputHandler):
         self.view = view
 
     def list_items(self):
-        return get_plugin_settings().get('python_interpreters')
+        all_py = get_plugin_settings().get('python_interpreters')
+
+        return all_py if all_py else []
 
     def confirm(self, sel_py):
-        get_plugin_settings().set('python_interpreter', sel_py)
-        sublime.save_settings('sublime_jedi.sublime-settings')
+        if sel_py:
+            get_plugin_settings().set('python_interpreter', sel_py)
+            sublime.save_settings('sublime_jedi.sublime-settings')
 
 
 class SublimeJediPySelect(PythonCommandMixin, sublime_plugin.TextCommand):

--- a/sublime_jedi/py_select.py
+++ b/sublime_jedi/py_select.py
@@ -1,6 +1,8 @@
 import sublime, sublime_plugin
 from .utils import PythonCommandMixin, is_python_scope
 from .settings import get_plugin_settings, get_settings_param
+from . import daemon
+from collections import defaultdict
 
 
 class PySelectEventListener(sublime_plugin.EventListener):
@@ -34,6 +36,8 @@ class ListAvaliablePython(sublime_plugin.ListInputHandler):
         if sel_py:
             get_plugin_settings().set('python_interpreter', sel_py)
             sublime.save_settings('sublime_jedi.sublime-settings')
+
+            daemon.DAEMONS = defaultdict(dict)
 
 
 class SublimeJediPySelect(PythonCommandMixin, sublime_plugin.TextCommand):


### PR DESCRIPTION

Add quick python select/switch function.

And when a python file is opened or activated, the python interpreter used by JEDI will show on statusbar.