### PR TITLE
Autocomplete function and classes on normal autocompletion

### DIFF
--- a/sublime_jedi/completion.py
+++ b/sublime_jedi/completion.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import re
+from threading import Timer
 
 import sublime
 import sublime_plugin
@@ -11,8 +12,33 @@ from .utils import get_settings, is_python_scope, is_repl
 
 logger = getLogger(__name__)
 FOLLOWING_CHARS = {"\r", "\n", "\t", " ", ")", "]", ";", "}", "\x00"}
-PLUGIN_ONLY_COMPLETION = (sublime.INHIBIT_WORD_COMPLETIONS |
-                          sublime.INHIBIT_EXPLICIT_COMPLETIONS)
+PLUGIN_ONLY_COMPLETION = (
+    sublime.INHIBIT_WORD_COMPLETIONS |
+    sublime.INHIBIT_EXPLICIT_COMPLETIONS
+)
+
+
+def debounce(wait):
+    """ Decorator that will postpone a functions
+        execution until after wait seconds
+        have elapsed since the last time it was invoked. """
+    def decorator(fn):
+        def debounced(*args, **kwargs):
+            def call_it():
+                fn(*args, **kwargs)
+            try:
+                debounced.t.cancel()
+            except(AttributeError):
+                pass
+            debounced.t = Timer(wait, call_it)
+            debounced.t.start()
+        return debounced
+    return decorator
+
+
+@debounce(0.2)
+def debounced_ask_daemon(*args, **kwargs):
+    ask_daemon(*args, **kwargs)
 
 
 class SublimeJediParamsAutocomplete(sublime_plugin.TextCommand):
@@ -160,7 +186,7 @@ class Autocomplete(sublime_plugin.ViewEventListener):
 
         if self._last_location != locations[0]:
             self._last_location = locations[0]
-            ask_daemon(
+            debounced_ask_daemon(
                 self.view,
                 self._receive_completions,
                 'autocomplete',
@@ -168,7 +194,7 @@ class Autocomplete(sublime_plugin.ViewEventListener):
             )
             return [], PLUGIN_ONLY_COMPLETION
 
-        if self._last_location == locations[0] and self._completions:
+        if self._last_location == locations[0]:
             self._last_location = None
             return self._completions
 
@@ -180,7 +206,6 @@ class Autocomplete(sublime_plugin.ViewEventListener):
 
         self._previous_completions = self._completions
         self._completions = completions
-
         if (completions and (
                 not view.is_auto_complete_visible() or
                 not self._is_completions_subset())):

--- a/sublime_jedi/daemon.py
+++ b/sublime_jedi/daemon.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from concurrent.futures import ThreadPoolExecutor
 
 from functools import wraps
 from collections import defaultdict
@@ -16,7 +15,6 @@ from .utils import get_settings
 logger = getLogger(__name__)
 
 DAEMONS = defaultdict(dict)  # per window
-REQUESTORS = defaultdict(dict)  # per window
 
 
 def _prepare_request_data(view, location):
@@ -34,13 +32,6 @@ def _get_daemon(view):
     if window_id not in DAEMONS:
         DAEMONS[window_id] = Daemon(settings=get_settings(view))
     return DAEMONS[window_id]
-
-
-def _get_requestor(view):
-    window_id = view.window().id()
-    if window_id not in REQUESTORS:
-        REQUESTORS[window_id] = ThreadPoolExecutor(max_workers=1)
-    return REQUESTORS[window_id]
 
 
 def ask_daemon_sync(view, ask_type, ask_kwargs, location=None):

--- a/sublime_jedi/facade.py
+++ b/sublime_jedi/facade.py
@@ -162,7 +162,6 @@ def format_completion(complete, with_keywords=True):
         final = str(len(params_insert) + 1)
         insert = complete.name + '(' + ', '.join(params_insert) + ')$' + final
         display = complete.name + '(' + ', '.join(params_display) + ')'
-        print(display, insert)
     else:
         display = complete.name
         insert = complete.name

--- a/sublime_jedi/facade.py
+++ b/sublime_jedi/facade.py
@@ -73,10 +73,9 @@ class JediFacade:
 
     def get_autocomplete(self, *args, **kwargs):
         """Jedi completion."""
-        complete_all = self.auto_complete_function_params == 'all'
         completions = chain(
             self._complete_call_assigments(with_keywords=True),
-            self._completion(with_keywords=complete_all)
+            self._completion()
         )
         return list(unique(completions, itemgetter(0)))
 
@@ -101,7 +100,7 @@ class JediFacade:
             else:
                 return defs[0].docstring()
 
-    def _completion(self, with_keywords=True):
+    def _completion(self):
         """Regular completions.
 
         :rtype: list of (str, str)

--- a/sublime_jedi/facade.py
+++ b/sublime_jedi/facade.py
@@ -108,7 +108,7 @@ class JediFacade:
         """
         completions = self.script.completions(fuzzy=True)
         for complete in completions:
-            yield format_completion(complete, with_keywords=with_keywords)
+            yield complete.name + '\t' + complete.type, complete.name
 
     def _goto(self, follow_imports):
         """Jedi "go to Definitions" functionality.
@@ -146,28 +146,6 @@ class JediFacade:
             return
 
         yield from get_function_parameters(call_definition, with_keywords)
-
-
-def format_completion(complete, with_keywords=True):
-    """Returns a tuple of the string that would be visible in
-    the completion dialogue and the completion word
-
-    :type complete: jedi.api_classes.Completion
-    :rtype: (str, str)
-    """
-    if complete.type == 'function':
-        params = list(get_function_parameters(complete, with_keywords))
-        params_insert = [i for _, i in params] or ['$1']
-        params_display = [d.split('\t', 1)[0] for d, _ in params]
-        final = str(len(params_insert) + 1)
-        insert = complete.name + '(' + ', '.join(params_insert) + ')$' + final
-        display = complete.name + '(' + ', '.join(params_display) + ')'
-    else:
-        display = complete.name
-        insert = complete.name
-
-    display += '\t' + complete.type
-    return display, insert
 
 
 def get_function_parameters(call_signature, with_keywords=True):

--- a/sublime_jedi/facade.py
+++ b/sublime_jedi/facade.py
@@ -155,7 +155,7 @@ def format_completion(complete, with_keywords=True):
     :type complete: jedi.api_classes.Completion
     :rtype: (str, str)
     """
-    if complete.type in ('function', 'class'):
+    if complete.type == 'function':
         params = list(get_function_parameters(complete, with_keywords))
         params_insert = [i for _, i in params] or ['$1']
         params_display = [d.split('\t', 1)[0] for d, _ in params]


### PR DESCRIPTION
Try it out... It provides parameter auto completion on the normal query completion. Example:

```python
def myfunction(a, b=1):
    pass
```

`myf|` will provide:

![Captura de pantalla_2020-04-09_17-13-43](https://user-images.githubusercontent.com/6555851/78910929-e2a62600-7a85-11ea-92d0-c53713cde14c.png)

and when selected will provide the parameter completion as the plugin already does.
