### PR TITLE
Re-Enable default goto popup

### DIFF
--- a/sublime_jedi/helper.py
+++ b/sublime_jedi/helper.py
@@ -88,6 +88,8 @@ class SublimeJediTooltip(sublime_plugin.EventListener):
     def on_activated(self, view):
         """Handle view.on_activated event."""
         if not (self.enabled() and view.match_selector(0, 'source.python')):
+            # enable default goto definition popup
+            view.settings().set('show_definitions', True)
             return
 
         # disable default goto definition popup


### PR DESCRIPTION
This modification re-enables the default goto popup when "enable_tooltip" is set to false.

In this moment jedi only sets the "show_definitions" setting to False when "enable_tooltip" is True but it never reset it back when you set it to False causing the default popup to never show up ever again (you have to enable it manually)