### PR TITLE
Add dependencies needed for sublime-markdown-popups

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -4,8 +4,10 @@
             "markupsafe",
             "mdpopups",
             "pygments",
+            "pymdownx",
             "python-jinja2",
-            "python-markdown"
+            "python-markdown",
+            "pyyaml"
         ]
     }
 }


### PR DESCRIPTION
This fixes #320 and makes the markdown popups a lot nicer!